### PR TITLE
Introduce `ContextRequireExceptionKeyRule`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
 struggle-for-php/sfp-phpstan-psr-log
 ============================
 
- - Deliver stubs to let PHPStan understand psr/log (PSR-3) strictly.
- 
-## Refs.
+## Installation
+
+```sh
+composer require --dev struggle-for-php/sfp-phpstan-psr-log
+```
+
+## Configuration
+
+In your `phpstan.neon` configuration, add following section:
+
+```neon
+includes:
+	- vendor/struggle-for-php/sfp-phpstan-psr-log/extension.neon
+	- vendor/struggle-for-php/sfp-phpstan-psr-log/rules.neon
+```
+
+## Stubs
+- Deliver stubs to let PHPStan understand psr/log (PSR-3) strictly.
+
 >  Implementors MUST still verify that the 'exception' key is actually an Exception before using it as such, as it MAY contain anything.
 
-https://www.php-fig.org/psr/psr-3/#13-context 
- 
-## Example
+https://www.php-fig.org/psr/psr-3/#13-context
+
+### Example
 
 ```php
 <?php
@@ -23,6 +39,7 @@ class Foo
     public function anyAction()
     {
         try {
+            // 
         } catch (\Exception $e) {
             $this->logger->error('error happen.', ['exception' => 'foo']);
         }
@@ -31,44 +48,47 @@ class Foo
 ```
 
 ```sh
-$ ../vendor/bin/phpstan analyse --level=5 src/
+$ ../vendor/bin/phpstan analyse
 Note: Using configuration file /tmp/your-project/phpstan.neon.
  2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
 
  ------ -------------------------------------------------------------
   Line   Demo.php
  ------ -------------------------------------------------------------
-  14     Parameter #2 $context of method Psr\Log\LoggerInterface::error() expects array()|array('exception' => Exception), array('exception' => 'foo') given.
+  15     Parameter #2 $context of method Psr\Log\LoggerInterface::error() expects array()|array('exception' => Exception), array('exception' => 'foo') given.
  ------ -------------------------------------------------------------
 
 
  [ERROR] Found 1 error
 ```
 
+## ContextRequireExceptionKeyRule
 
-## Installation
+- Require set exception into context parameter when current scope has Throwable object.
+
+### Example
+
+```php
+<?php
+/** @var \Psr\Log\LoggerInterface $logger */
+try {
+    // 
+} catch (LogicException $exception) {
+    $logger->warning("foo");
+}
+```
 
 ```sh
-composer require --dev struggle-for-php/sfp-phpstan-psr-log
+$ ../vendor/bin/phpstan analyse
+Note: Using configuration file /tmp/your-project/phpstan.neon.
+ 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
+
+ ------ -------------------------------------------------------------
+  Line   Demo.php
+ ------ -------------------------------------------------------------
+  6      Parameter $context of logger method Psr\Log\LoggerInterface::warning() requires \'exception\' key. Current scope has Throwable variable - $exception
+ ------ -------------------------------------------------------------
+
+
+ [ERROR] Found 1 error
 ```
-
-## Configuration
-
-In your `phpstan.neon` configuration, add following section:
-
-```neon
-includes:
-	- vendor/struggle-for-php/sfp-phpstan-psr-log/extension.neon
-```
-
-## Unit Test
-
-needs separated running per Test suite
-```
-./vendor/bin/phpunit tests/StubTest.php
-./vendor/bin/phpunit tests/ThrowableStubTest.php
-```
-
-## Notes
-* `Psr\Log\InvalidArgumentException` file is needed for stub.
-     - see https://github.com/phpstan/phpstan/issues/3124

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,11 @@
         "roave/security-advisories": "dev-master",
         "phpunit/phpunit": "^9.5.10"
     },
+    "autoload": {
+        "psr-4": {
+            "Sfp\\PHPStan\\Psr\\Log\\": "src"
+        }
+    },
     "autoload-dev": {
         "psr-4": {
             "SfpTest\\PHPStan\\Psr\\Log\\": "test"

--- a/rules.neon
+++ b/rules.neon
@@ -1,0 +1,2 @@
+rules:
+	- Sfp\PHPStan\Psr\Log\Rules\DqlRule

--- a/src/Rules/ContextRequireExceptionKeyRule.php
+++ b/src/Rules/ContextRequireExceptionKeyRule.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Sfp\PHPStan\Psr\Log\Rules;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PhpParser\Node;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ObjectType;
+
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
+class ContextRequireExceptionKeyRule implements Rule
+{
+    private const LOGGER_LEVEL_METHODS = [
+        'emergency',
+        'alert',
+        'critical',
+        'error',
+        'warning',
+        'notice',
+        'info',
+        'debug'
+    ];
+
+    private const ERROR_MISSED_EXCEPTION_KEY = 'Parameter $context of logger method Psr\Log\LoggerInterface::%s() requires \'exception\' key. Current scope has Throwable variable - %s';
+
+    public function getNodeType() : string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    /**
+     * @param Node\Expr\MethodCall $node
+     * @throws ShouldNotHappenException
+     */
+    public function processNode(Node $node, Scope $scope) : array
+    {
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $calledOnType = $scope->getType($node->var);
+        if (!(new ObjectType('Psr\Log\LoggerInterface'))->isSuperTypeOf($calledOnType)->yes()) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+        if (count($args) === 0) {
+            return [];
+        }
+
+        $methodName = $node->name->toLowerString();
+
+        $contextArgumentNo = 1;
+        if ($methodName === 'log') {
+            if (count($args) === 1) {
+                return [];
+            }
+            $contextArgumentNo = 2;
+        } elseif (!in_array($methodName, self::LOGGER_LEVEL_METHODS)) {
+            return [];
+        }
+
+        $throwable = $this->findCurrentScopeThrowableVariable($scope);
+
+        if ($throwable === null) {
+            return [];
+        }
+
+        if (! isset($args[$contextArgumentNo])) {
+            return [sprintf(self::ERROR_MISSED_EXCEPTION_KEY, $methodName, "\${$throwable}")];
+        }
+
+        $context = $args[$contextArgumentNo];
+
+        if ($context instanceof Node\VariadicPlaceholder) {
+            return [];
+        }
+
+        if ($context instanceof Node\Arg && self::contextDoesNotHavExceptionKey($context)) {
+            return [sprintf(self::ERROR_MISSED_EXCEPTION_KEY, $methodName, "\${$throwable}")];
+        }
+
+        return [];
+    }
+
+    private function findCurrentScopeThrowableVariable(Scope $scope) : ?string
+    {
+        foreach ($scope->getDefinedVariables() as $var) {
+            if ((new ObjectType(\Throwable::class))->isSuperTypeOf($scope->getVariableType($var))->yes()) {
+                return $var;
+            }
+        }
+
+        return null;
+    }
+
+    private static function contextDoesNotHavExceptionKey(Node\Arg $context) : bool
+    {
+        if (! $context->value instanceof Node\Expr\Array_) {
+            return true;
+        }
+
+        if (count($context->value->items) === 0 ) {
+            return true;
+        }
+
+        foreach ($context->value->items as $item) {
+            assert($item->key instanceof Node\Scalar\String_);
+            if ($item->key->value === 'exception') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/test/Rules/ContextRequireExceptionKeyRuleTest.php
+++ b/test/Rules/ContextRequireExceptionKeyRuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SfpTest\PHPStan\Psr\Log\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule;
+
+/**
+ * @implements RuleTestCase<ContextRequireExceptionKeyRule>
+ */
+class ContextRequireExceptionKeyRuleTest extends RuleTestCase
+{
+    protected function getRule() : Rule
+    {
+        return new ContextRequireExceptionKeyRule();
+    }
+
+    /** @test */
+    public function testProcessNode()
+    {
+        $this->analyse([__DIR__ . '/data/contextRequireExceptionKey.php'], [
+            'missing context' => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::info() requires \'exception\' key. Current scope has Throwable variable - $exception',
+                13,
+            ],
+            'invalid key' => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::info() requires \'exception\' key. Current scope has Throwable variable - $exception',
+                14,
+            ],
+            'missing context - log method' => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception',
+                17,
+            ],
+            'invalid key - log method' => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception',
+                18,
+            ],
+            'missing context - other catch' => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::critical() requires \'exception\' key. Current scope has Throwable variable - $exception2',
+                24,
+            ],
+            'invalid key - other catch' => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception2',
+                25,
+            ],
+        ]);
+    }
+}

--- a/test/Rules/data/contextRequireExceptionKey.php
+++ b/test/Rules/data/contextRequireExceptionKey.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @var \Psr\Log\LoggerInterface $logger
+ */
+
+try {
+    $logger->debug("foo"); // allow
+    $logger->log('debug', "foo"); // allow
+
+    throw new InvalidArgumentException();
+} catch (LogicException $exception) {
+    $logger->info("foo");
+    $logger->info('foo', ['throwable' => $exception]);
+
+    // log method
+    $logger->log('notice', 'foo');
+    $logger->log('notice', 'foo', ['throwable' => $exception]);
+
+    // ok
+    $logger->alert("foo", ['exception' => $exception]);
+    $logger->log('alert', 'foo', ['exception' => $exception]);
+} catch (RuntimeException|Throwable $exception2) {
+    $logger->critical('foo');
+    $logger->log('critical', 'foo');
+
+    $logger->critical("foo", ['exception' => $exception2]);
+} finally {
+    $logger->emergency('foo');
+}


### PR DESCRIPTION
### Example

```php
<?php
/** @var \Psr\Log\LoggerInterface $logger */
try {
    // 
} catch (LogicException $exception) {
    $logger->warning("foo");
}
```

```sh
$ ../vendor/bin/phpstan analyse
Note: Using configuration file /tmp/your-project/phpstan.neon.
 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------------
  Line   Demo.php
 ------ -------------------------------------------------------------
  6      Parameter $context of logger method Psr\Log\LoggerInterface::warning() requires \'exception\' key. Current scope has Throwable variable - $exception
 ------ -------------------------------------------------------------


 [ERROR] Found 1 error
```
