### PR TITLE
Support specify LogLevel to report for `ContextRequireExceptionKeyRule`

### DIFF
--- a/example/phpstan.neon
+++ b/example/phpstan.neon
@@ -2,11 +2,13 @@
 # ./vendor/bin/phpstan analyse -c ./example/phpstan.neon --level 5 example/
 
 parameters:
-    level: 5
+    level: 9
     bootstrapFiles:
         - vendor/autoload.php
     paths:
         - src
+    sfpPsrLog:
+        reportContextExceptionLogLevel: 'notice'
 
 includes:
 	- ../extension.neon

--- a/example/src/Example.php
+++ b/example/src/Example.php
@@ -17,16 +17,25 @@ class Example
     public function exceptionKeyOnlyAllowThrowable(\Throwable $throwable): void
     {
         // invalid
-        $this->logger->debug('foo', ['exception' => $throwable->getMessage()]);
+        $this->logger->notice('foo', ['exception' => $throwable->getMessage()]);
         $this->logger->log('panic', 'foo', ['exception' => $throwable]);
 
         // valid
-        $this->logger->log('info', 'foo', ['exception' => $throwable]);
+        $this->logger->log('notice', 'foo', ['exception' => $throwable]);
     }
 
-    public function mustIncludesCurrentScopeThrowableIntoContext(\Throwable $throwable)
+    public function mustIncludesCurrentScopeThrowableIntoContext(\Throwable $throwable): void
     {
         // Parameter $context of logger method Psr\Log\LoggerInterface::info() requires 'exception' key. Current scope has Throwable variable - $throwable
-        $this->logger->info('foo');
+        $this->logger->notice('foo');
+
+        $this->logger->notice('foo', ['user' => 1]);
+    }
+
+    public function reportContextExceptionLogLevel(\Throwable $throwable): void
+    {
+        // phpstan.neon sfpPsrLog.reportContextExceptionLogLevel is 'notice'
+        // so bellow would not report.
+        $this->logger->debug('foo');
     }
 }

--- a/rules.neon
+++ b/rules.neon
@@ -1,2 +1,16 @@
-rules:
-	- Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
+parameters:
+    sfpPsrLog:
+        reportContextExceptionLogLevel: 'debug'
+
+parametersSchema:
+	sfpPsrLog: structure([
+		reportContextExceptionLogLevel: schema(string(), nullable())
+	])
+
+services:
+	-
+		class: Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
+		arguments:
+			reportContextExceptionLogLevel: %sfpPsrLog.reportContextExceptionLogLevel%
+		tags:
+			- phpstan.rules.rule

--- a/test/Rules/ContextRequireExceptionKeyRuleTest.php
+++ b/test/Rules/ContextRequireExceptionKeyRuleTest.php
@@ -13,7 +13,7 @@ class ContextRequireExceptionKeyRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
-        return new ContextRequireExceptionKeyRule();
+        return new ContextRequireExceptionKeyRule('info');
     }
 
     /** @test */
@@ -22,27 +22,27 @@ class ContextRequireExceptionKeyRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/contextRequireExceptionKey.php'], [
             'missing context'               => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::info() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                15,
+                17,
             ],
             'invalid key'                   => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::info() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                16,
+                18,
             ],
             'missing context - log method'  => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                19,
+                21,
             ],
             'invalid key - log method'      => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                20,
+                22,
             ],
             'missing context - other catch' => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::critical() requires \'exception\' key. Current scope has Throwable variable - $exception2',
-                26,
+                29,
             ],
             'invalid key - other catch'     => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception2',
-                27,
+                30,
             ],
         ]);
     }

--- a/test/Rules/data/contextRequireExceptionKey.php
+++ b/test/Rules/data/contextRequireExceptionKey.php
@@ -7,15 +7,17 @@
 // phpcs:enable
 
 try {
-    $logger->debug("foo"); // allow
-    $logger->log('debug', "foo"); // allow
+    $logger->debug("foo");
+    $logger->log('debug', "foo");
 
     throw new InvalidArgumentException();
 } catch (LogicException $exception) {
+    // ng
+    $logger->debug("foo"); // but would not be report
     $logger->info("foo");
     $logger->info('foo', ['throwable' => $exception]);
 
-    // log method
+    // ng. (by `log` call)
     $logger->log('notice', 'foo');
     $logger->log('notice', 'foo', ['throwable' => $exception]);
 
@@ -23,10 +25,14 @@ try {
     $logger->alert("foo", ['exception' => $exception]);
     $logger->log('alert', 'foo', ['exception' => $exception]);
 } catch (RuntimeException | Throwable $exception2) {
+    // ng
     $logger->critical('foo');
     $logger->log('critical', 'foo');
+    $logger->debug("foo", ['exception' => new DateTimeImmutable()]); // but would not be report
 
+    // ok
     $logger->critical("foo", ['exception' => $exception2]);
 } finally {
+    // ok
     $logger->emergency('foo');
 }


### PR DESCRIPTION
fix #10 

You can specify LogLevel to report.

```
parameters:
    sfpPsrLog:
        reportContextExceptionLogLevel: 'warning'
```

Then, `debug`| `info` | `notice` LogLevel  is ignored for report.
```php
} catch (\Exception $e)
$logger->info('more info'); // allow
$logger->warning($e->getMessage(), ['exception' => $e]);
```