### PR TITLE
introduce NonEmptyStringKeyRule

### DIFF
--- a/src/Rules/ContextRequireExceptionKeyRule.php
+++ b/src/Rules/ContextRequireExceptionKeyRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sfp\PHPStan\Psr\Log\Rules;
 
 use PhpParser\Node;
@@ -18,17 +20,6 @@ use function sprintf;
  */
 class ContextRequireExceptionKeyRule implements Rule
 {
-    private const LOGGER_LEVEL_METHODS = [
-        'emergency',
-        'alert',
-        'critical',
-        'error',
-        'warning',
-        'notice',
-        'info',
-        'debug',
-    ];
-
     private const LOGGER_LEVELS = [
         'emergency' => 7,
         'alert'     => 6,
@@ -90,7 +81,7 @@ class ContextRequireExceptionKeyRule implements Rule
 
             $logLevel          = $args[0]->value->value;
             $contextArgumentNo = 2;
-        } elseif (! in_array($methodName, self::LOGGER_LEVEL_METHODS)) {
+        } elseif (! in_array($methodName, LogLevelListInterface::LOGGER_LEVEL_METHODS)) {
             return [];
         }
 

--- a/src/Rules/LogLevelListInterface.php
+++ b/src/Rules/LogLevelListInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sfp\PHPStan\Psr\Log\Rules;
+
+interface LogLevelListInterface
+{
+    public const LOGGER_LEVEL_METHODS = [
+        'emergency',
+        'alert',
+        'critical',
+        'error',
+        'warning',
+        'notice',
+        'info',
+        'debug',
+    ];
+}

--- a/src/Rules/NonEmptyStringKeyRule.php
+++ b/src/Rules/NonEmptyStringKeyRule.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sfp\PHPStan\Psr\Log\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ObjectType;
+
+use function count;
+use function in_array;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
+class NonEmptyStringKeyRule implements Rule
+{
+    // eg, DNumber
+    private const ERROR_UNEXPECTED_KEY = 'Parameter $context of logger method Psr\Log\LoggerInterface::%s() , key should be non empty string.';
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    /**
+     * @param Node\Expr\MethodCall $node
+     * @throws ShouldNotHappenException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $calledOnType = $scope->getType($node->var);
+        if (! (new ObjectType('Psr\Log\LoggerInterface'))->isSuperTypeOf($calledOnType)->yes()) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+        if (count($args) === 0) {
+            return [];
+        }
+
+        $methodName = $node->name->toLowerString();
+
+        $contextArgumentNo = 1;
+        if ($methodName === 'log') {
+            if (
+                count($args) < 2
+                || ! $args[0] instanceof Node\Arg
+                || ! $args[0]->value instanceof Node\Scalar\String_
+            ) {
+                return [];
+            }
+
+            $contextArgumentNo = 2;
+        } elseif (! in_array($methodName, LogLevelListInterface::LOGGER_LEVEL_METHODS)) {
+            return [];
+        }
+
+        $context = $args[$contextArgumentNo];
+
+        if ($context instanceof Node\VariadicPlaceholder) {
+            return [];
+        }
+
+        if (! $context instanceof Node\Arg) {
+            return [];
+        }
+
+        return self::keysAreNonEmptyString($context, $methodName);
+    }
+
+    private static function keysAreNonEmptyString(Node\Arg $context, string $methodName): array
+    {
+        if (! $context->value instanceof Node\Expr\Array_) {
+            return [];
+        }
+
+        if (count($context->value->items) === 0) {
+            return [];
+        }
+
+        $indexes = [];
+        foreach ($context->value->items as $item) {
+            if ($item->key instanceof Node\Scalar\String_ && $item->key->value !== '') {
+                continue;
+            }
+
+            $indexes[] = sprintf(self::ERROR_UNEXPECTED_KEY, $methodName);
+        }
+
+        return $indexes;
+    }
+}

--- a/test/Rules/ContextRequireExceptionKeyRuleTest.php
+++ b/test/Rules/ContextRequireExceptionKeyRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SfpTest\PHPStan\Psr\Log\Rules;
 
 use PHPStan\Rules\Rule;
@@ -9,7 +11,7 @@ use Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule;
 /**
  * @implements RuleTestCase<ContextRequireExceptionKeyRule>
  */
-class ContextRequireExceptionKeyRuleTest extends RuleTestCase
+final class ContextRequireExceptionKeyRuleTest extends RuleTestCase
 {
     protected function getRule(): Rule
     {
@@ -22,27 +24,27 @@ class ContextRequireExceptionKeyRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/contextRequireExceptionKey.php'], [
             'missing context'               => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::info() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                13,
+                15,
             ],
             'invalid key'                   => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::info() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                14,
+                16,
             ],
             'missing context - log method'  => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                17,
+                19,
             ],
             'invalid key - log method'      => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                18,
+                20,
             ],
             'missing context - other catch' => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::critical() requires \'exception\' key. Current scope has Throwable variable - $exception2',
-                25,
+                27,
             ],
             'invalid key - other catch'     => [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception2',
-                26,
+                28,
             ],
         ]);
     }

--- a/test/Rules/NonEmptyStringKeyRuleTest.php
+++ b/test/Rules/NonEmptyStringKeyRuleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SfpTest\PHPStan\Psr\Log\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Sfp\PHPStan\Psr\Log\Rules\NonEmptyStringKeyRule;
+
+/**
+ * @implements RuleTestCase<NonEmptyStringKeyRule>
+ */
+final class NonEmptyStringKeyRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NonEmptyStringKeyRule();
+    }
+
+    /** @test */
+    public function testProcessNode()
+    {
+        $this->analyse([__DIR__ . '/data/nonEmptyStringKey.php'], [
+            'empty string'  => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::info() , key should be non empty string.',
+                8,
+            ],
+            'integer'       => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::info() , key should be non empty string.',
+                9,
+            ],
+            'DNumber'       => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::info() , key should be non empty string.',
+                10,
+            ],
+            'not specified' => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::info() , key should be non empty string.',
+                11,
+            ],
+        ]);
+    }
+}

--- a/test/Rules/data/contextRequireExceptionKey.php
+++ b/test/Rules/data/contextRequireExceptionKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function main(Psr\Log\LoggerInterface $logger): void
 {
     try {

--- a/test/Rules/data/nonEmptyStringKey.php
+++ b/test/Rules/data/nonEmptyStringKey.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+function main(Psr\Log\LoggerInterface $logger): void
+{
+    $logger->info('foo', ['ok' => "a"]);
+    $logger->info('foo', ['' => "a"]);
+    $logger->info('foo', [1 => "a"]);
+    $logger->info('foo', [12345678901234567890 => "a"]);
+    $logger->info('foo', ["a"]);
+}


### PR DESCRIPTION
```php
function main(Psr\Log\LoggerInterface $logger): void
{
    $logger->info('foo', ['ok' => "a"]);

    // errors
    $logger->info('foo', ['' => "a"]);
    $logger->info('foo', [1 => "a"]);
    $logger->info('foo', [12345678901234567890 => "a"]);
    $logger->info('foo', ["a"]);
}
```