### PR TITLE
Added PlaceHolderInMessageRule

### DIFF
--- a/example/src/Example.php
+++ b/example/src/Example.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace src;
 
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 class Example
 {
@@ -14,7 +17,7 @@ class Example
         $this->logger = $logger;
     }
 
-    public function exceptionKeyOnlyAllowThrowable(\Throwable $throwable): void
+    public function exceptionKeyOnlyAllowThrowable(Throwable $throwable): void
     {
         // invalid
         $this->logger->notice('foo', ['exception' => $throwable->getMessage()]);
@@ -24,7 +27,7 @@ class Example
         $this->logger->log('notice', 'foo', ['exception' => $throwable]);
     }
 
-    public function mustIncludesCurrentScopeThrowableIntoContext(\Throwable $throwable): void
+    public function mustIncludesCurrentScopeThrowableIntoContext(Throwable $throwable): void
     {
         // Parameter $context of logger method Psr\Log\LoggerInterface::info() requires 'exception' key. Current scope has Throwable variable - $throwable
         $this->logger->notice('foo');
@@ -32,15 +35,23 @@ class Example
         $this->logger->notice('foo', ['user' => 1]);
     }
 
-    public function reportContextExceptionLogLevel(\Throwable $throwable): void
+    public function reportContextExceptionLogLevel(Throwable $throwable): void
     {
         // phpstan.neon sfpPsrLog.reportContextExceptionLogLevel is 'notice'
         // so bellow would not report.
         $this->logger->debug('foo');
     }
 
-    public function emptyKey(): void
+    public function nonEmptyStringKey(): void
     {
         $this->logger->debug('foo', ['bar']);
+    }
+
+    public function placeHolderInMessage(): void
+    {
+        $this->logger->info('message has {{doubleBrace}} .', ['doubleBrace' => 'bar']);
+        $this->logger->info('message has { space } .', [' space ' => 'bar']);
+        $this->logger->info('message has prev{foo} .', ['foo' => 'bar']);
+        $this->logger->info('message has {foo}back ..', ['foo' => 'bar']);
     }
 }

--- a/example/src/Example.php
+++ b/example/src/Example.php
@@ -51,7 +51,5 @@ class Example
     {
         $this->logger->info('message has {{doubleBrace}} .', ['doubleBrace' => 'bar']);
         $this->logger->info('message has { space } .', [' space ' => 'bar']);
-        $this->logger->info('message has prev{foo} .', ['foo' => 'bar']);
-        $this->logger->info('message has {foo}back ..', ['foo' => 'bar']);
     }
 }

--- a/rules.neon
+++ b/rules.neon
@@ -9,6 +9,7 @@ parametersSchema:
 
 rules:
     - Sfp\PHPStan\Psr\Log\Rules\NonEmptyStringKeyRule
+    - Sfp\PHPStan\Psr\Log\Rules\PlaceHolderInMessageRule
 
 services:
 	-

--- a/src/Rules/PlaceHolderInMessageRule.php
+++ b/src/Rules/PlaceHolderInMessageRule.php
@@ -104,7 +104,7 @@ final class PlaceHolderInMessageRule implements Rule
 
         $invalidPlaceHolders = [];
         foreach ($matches[1] as $i => $placeholderCandidate) {
-            if (preg_match('#\A[A-Za-z0-9_\.]+\z#', $placeholderCandidate) === 0) {
+            if (preg_match('#\A[A-Za-z0-9_\.]+\z#', $placeholderCandidate) !== 1) {
                 $invalidPlaceHolders[$i] = $matches[0][$i];
             }
         }

--- a/src/Rules/PlaceHolderInMessageRule.php
+++ b/src/Rules/PlaceHolderInMessageRule.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sfp\PHPStan\Psr\Log\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ObjectType;
+
+use function count;
+use function implode;
+use function in_array;
+use function preg_match;
+use function preg_match_all;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
+final class PlaceHolderInMessageRule implements Rule
+{
+    private const ERROR_DOUBLE_BRACES              = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() should not includes double braces. - %s';
+    private const ERROR_INVALID_CHAR               = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() has braces. But it includes invalid characters for placeholder. - %s';
+    private const ERROR_NO_WHITESPACE_BETWEEN_WORD = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() has braces. There should be whitespace between placeholder and word.';
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    /**
+     * @param Node\Expr\MethodCall $node
+     * @throws ShouldNotHappenException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $calledOnType = $scope->getType($node->var);
+        if (! (new ObjectType('Psr\Log\LoggerInterface'))->isSuperTypeOf($calledOnType)->yes()) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+        if (count($args) === 0) {
+            return [];
+        }
+
+        $methodName = $node->name->toLowerString();
+
+        $messageArgumentNo = 0;
+        if ($methodName === 'log') {
+            if (
+                count($args) < 2
+                || ! $args[0] instanceof Node\Arg
+                || ! $args[0]->value instanceof Node\Scalar\String_
+            ) {
+                return [];
+            }
+
+            $messageArgumentNo = 1;
+        } elseif (! in_array($methodName, LogLevelListInterface::LOGGER_LEVEL_METHODS)) {
+            return [];
+        }
+
+        $message = $args[$messageArgumentNo];
+
+        if (! $message->value instanceof Node\Scalar\String_) {
+            return [];
+        }
+
+        $errors = [];
+
+        $errors += self::checkDoubleBrace($message->value->value, $methodName);
+        $errors += self::checkInvalidChar($message->value->value, $methodName);
+        $errors += self::checkNoSpaceBetweenWord($message->value->value, $methodName);
+
+        return $errors;
+    }
+
+    private static function checkDoubleBrace(string $message, string $methodName): array
+    {
+        $matched = preg_match_all('#{{(.+?)}}#', $message, $matches);
+
+        if ($matched === 0 || $matched === false) {
+            return [];
+        }
+
+        return [sprintf(self::ERROR_DOUBLE_BRACES, $methodName, implode(',', $matches[0]))];
+    }
+
+    private static function checkInvalidChar(string $message, string $methodName): array
+    {
+        $matched = preg_match_all('#{(.+?)}#', $message, $matches);
+
+        if ($matched === 0 || $matched === false) {
+            return [];
+        }
+
+        $invalidPlaceHolders = [];
+        foreach ($matches[1] as $i => $placeholderCandidate) {
+            if (preg_match('#\A[A-Za-z0-9_\.]+\z#', $placeholderCandidate) === 0) {
+                $invalidPlaceHolders[$i] = $matches[0][$i];
+            }
+        }
+
+        if (count($invalidPlaceHolders) === 0) {
+            return [];
+        }
+
+        return [sprintf(self::ERROR_INVALID_CHAR, $methodName, implode(',', $invalidPlaceHolders))];
+    }
+
+    private static function checkNoSpaceBetweenWord(string $message, string $methodName): array
+    {
+        preg_match('#\A.*?([\w]+?)*{[A-Za-z0-9_\.]+}([\w]+?)*.*\z#', $message, $matches);
+
+        if (count($matches) < 2) {
+            return [];
+        }
+
+        return [sprintf(self::ERROR_NO_WHITESPACE_BETWEEN_WORD, $methodName)];
+    }
+}

--- a/src/Rules/PlaceHolderInMessageRule.php
+++ b/src/Rules/PlaceHolderInMessageRule.php
@@ -22,9 +22,8 @@ use function sprintf;
  */
 final class PlaceHolderInMessageRule implements Rule
 {
-    private const ERROR_DOUBLE_BRACES              = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() should not includes double braces. - %s';
-    private const ERROR_INVALID_CHAR               = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() has braces. But it includes invalid characters for placeholder. - %s';
-    private const ERROR_NO_WHITESPACE_BETWEEN_WORD = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() has braces. There should be whitespace between placeholder and word.';
+    private const ERROR_DOUBLE_BRACES = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() should not includes double braces. - %s';
+    private const ERROR_INVALID_CHAR  = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() has braces. But it includes invalid characters for placeholder. - %s';
 
     public function getNodeType(): string
     {
@@ -78,7 +77,6 @@ final class PlaceHolderInMessageRule implements Rule
 
         $errors += self::checkDoubleBrace($message->value->value, $methodName);
         $errors += self::checkInvalidChar($message->value->value, $methodName);
-        $errors += self::checkNoSpaceBetweenWord($message->value->value, $methodName);
 
         return $errors;
     }
@@ -114,16 +112,5 @@ final class PlaceHolderInMessageRule implements Rule
         }
 
         return [sprintf(self::ERROR_INVALID_CHAR, $methodName, implode(',', $invalidPlaceHolders))];
-    }
-
-    private static function checkNoSpaceBetweenWord(string $message, string $methodName): array
-    {
-        preg_match('#\A.*?([\w]+?)*{[A-Za-z0-9_\.]+}([\w]+?)*.*\z#', $message, $matches);
-
-        if (count($matches) < 2) {
-            return [];
-        }
-
-        return [sprintf(self::ERROR_NO_WHITESPACE_BETWEEN_WORD, $methodName)];
     }
 }

--- a/test/Rules/PlaceHolderInMessageRuleTest.php
+++ b/test/Rules/PlaceHolderInMessageRuleTest.php
@@ -22,25 +22,29 @@ final class PlaceHolderInMessageRuleTest extends RuleTestCase
     public function testProcessNode(): void
     {
         $this->analyse([__DIR__ . '/data/placeHolderInMessage.php'], [
-            'double braces'            => [
+            'double braces'             => [
                 'Parameter $message of logger method Psr\Log\LoggerInterface::info() should not includes double braces. - {{doubleBrace}}',
                 15,
             ],
-            'invalid placeholder char' => [
+            'invalid placeholder char'  => [
                 'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. But it includes invalid characters for placeholder. - { space }',
                 16,
             ],
-            'non space before braces'  => [
+            'non space before braces'   => [
                 'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. There should be whitespace between placeholder and word.',
                 17,
             ],
-            'non space after braces'   => [
+            'non space after braces'    => [
                 'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. There should be whitespace between placeholder and word.',
                 18,
             ],
-            'call log() method'        => [
+            'call log() method'         => [
                 'Parameter $message of logger method Psr\Log\LoggerInterface::log() has braces. But it includes invalid characters for placeholder. - {&invalid&}',
                 19,
+            ],
+            'Many Invalid PlaceHolders' => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. But it includes invalid characters for placeholder. - {&a},{&b},{&c}',
+                20,
             ],
         ]);
     }

--- a/test/Rules/PlaceHolderInMessageRuleTest.php
+++ b/test/Rules/PlaceHolderInMessageRuleTest.php
@@ -38,6 +38,10 @@ final class PlaceHolderInMessageRuleTest extends RuleTestCase
                 'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. There should be whitespace between placeholder and word.',
                 18,
             ],
+            'call log() method'        => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::log() has braces. But it includes invalid characters for placeholder. - {&invalid&}',
+                19,
+            ],
         ]);
     }
 }

--- a/test/Rules/PlaceHolderInMessageRuleTest.php
+++ b/test/Rules/PlaceHolderInMessageRuleTest.php
@@ -30,21 +30,13 @@ final class PlaceHolderInMessageRuleTest extends RuleTestCase
                 'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. But it includes invalid characters for placeholder. - { space }',
                 16,
             ],
-            'non space before braces'   => [
-                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. There should be whitespace between placeholder and word.',
-                17,
-            ],
-            'non space after braces'    => [
-                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. There should be whitespace between placeholder and word.',
-                18,
-            ],
             'call log() method'         => [
                 'Parameter $message of logger method Psr\Log\LoggerInterface::log() has braces. But it includes invalid characters for placeholder. - {&invalid&}',
-                19,
+                17,
             ],
             'Many Invalid PlaceHolders' => [
                 'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. But it includes invalid characters for placeholder. - {&a},{&b},{&c}',
-                20,
+                18,
             ],
         ]);
     }

--- a/test/Rules/PlaceHolderInMessageRuleTest.php
+++ b/test/Rules/PlaceHolderInMessageRuleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SfpTest\PHPStan\Psr\Log\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Sfp\PHPStan\Psr\Log\Rules\PlaceHolderInMessageRule;
+
+/**
+ * @implements RuleTestCase<PlaceHolderInMessageRule>
+ */
+final class PlaceHolderInMessageRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new PlaceHolderInMessageRule();
+    }
+
+    /** @test */
+    public function testProcessNode(): void
+    {
+        $this->analyse([__DIR__ . '/data/placeHolderInMessage.php'], [
+            'double braces'            => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() should not includes double braces. - {{doubleBrace}}',
+                15,
+            ],
+            'invalid placeholder char' => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. But it includes invalid characters for placeholder. - { space }',
+                16,
+            ],
+            'non space before braces'  => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. There should be whitespace between placeholder and word.',
+                17,
+            ],
+            'non space after braces'   => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. There should be whitespace between placeholder and word.',
+                18,
+            ],
+        ]);
+    }
+}

--- a/test/Rules/data/placeHolderInMessage.php
+++ b/test/Rules/data/placeHolderInMessage.php
@@ -16,4 +16,5 @@ function main(Psr\Log\LoggerInterface $logger, string $m): void
     $logger->info('message has { space } .', [' space ' => 'bar']);
     $logger->info('message has prev{foo} .', ['foo' => 'bar']);
     $logger->info('message has {foo}back ..', ['foo' => 'bar']);
+    $logger->log('info', 'message has {&invalid&} .', ['&invalid&' => 'bar']);
 }

--- a/test/Rules/data/placeHolderInMessage.php
+++ b/test/Rules/data/placeHolderInMessage.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+function main(Psr\Log\LoggerInterface $logger, string $m): void
+{
+    // ignore
+    $logger->info('foo', ['ok' => "a"]);
+    $logger->info($m, ['ok' => "a"]);
+    // valid
+    $logger->info('message is {valid1_.} ..', ['valid' => 'OK']);
+    $logger->info('message is {valid1_.}.', ['valid' => 'OK']);
+    $logger->info('メッセージは{valid1_.}です', ['valid' => 'OK']);
+
+    $logger->info('message has {{doubleBrace}} .', ['doubleBrace' => 'bar']);
+    $logger->info('message has { space } .', [' space ' => 'bar']);
+    $logger->info('message has prev{foo} .', ['foo' => 'bar']);
+    $logger->info('message has {foo}back ..', ['foo' => 'bar']);
+}

--- a/test/Rules/data/placeHolderInMessage.php
+++ b/test/Rules/data/placeHolderInMessage.php
@@ -14,8 +14,6 @@ function main(Psr\Log\LoggerInterface $logger, string $m): void
 
     $logger->info('message has {{doubleBrace}} .', ['doubleBrace' => 'bar']);
     $logger->info('message has { space } .', [' space ' => 'bar']);
-    $logger->info('message has prev{foo} .', ['foo' => 'bar']);
-    $logger->info('message has {foo}back ..', ['foo' => 'bar']);
     $logger->log('info', 'message has {&invalid&} .', ['&invalid&' => 'bar']);
     $logger->info('message has {&a} , {&b} , {valid} and {&c} .', ['&a' => 'bar', '&b' => 'bar', 'valid' => 'bar', '&c' => 'bar']);
 }

--- a/test/Rules/data/placeHolderInMessage.php
+++ b/test/Rules/data/placeHolderInMessage.php
@@ -17,4 +17,5 @@ function main(Psr\Log\LoggerInterface $logger, string $m): void
     $logger->info('message has prev{foo} .', ['foo' => 'bar']);
     $logger->info('message has {foo}back ..', ['foo' => 'bar']);
     $logger->log('info', 'message has {&invalid&} .', ['&invalid&' => 'bar']);
+    $logger->info('message has {&a} , {&b} , {valid} and {&c} .', ['&a' => 'bar', '&b' => 'bar', 'valid' => 'bar', '&c' => 'bar']);
 }


### PR DESCRIPTION
fixes #12

As example, 
```php
        $this->logger->info('message has {{doubleBrace}} .', ['doubleBrace' => 'bar']);
        $this->logger->info('message has { space } .', [' space ' => 'bar']);
```

```
./vendor/bin/phpstan analyse -c example/phpstan.neon
```
would report


```
  52     Parameter $message of logger method Psr\Log\LoggerInterface::info() should not includes double braces. - {{doubleBrace}}
  53     Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. But it includes invalid characters for placeholder. - { space }
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------
```