### PR TITLE
Add ContextKeyPlaceHolderRule

### DIFF
--- a/example/src/Example.php
+++ b/example/src/Example.php
@@ -52,4 +52,13 @@ class Example
         $this->logger->info('message has {{doubleBrace}} .', ['doubleBrace' => 'bar']);
         $this->logger->info('message has { space } .', [' space ' => 'bar']);
     }
+
+    public function contextKeyPlaceHolder(): void
+    {
+        $this->logger->info('message has {nonContext} .');
+        $this->logger->info('message has {empty} .', []);
+        $this->logger->info('message has {notMatched} .', ['foo' => 'bar']);
+        $this->logger->info('message has {notMatched1} , {matched1} , {notMatched2} .', ['matched1' => 'bar']);
+        $this->logger->log('info', 'message has {notMatched} .', ['foo' => 'bar']);
+    }
 }

--- a/rules.neon
+++ b/rules.neon
@@ -8,6 +8,7 @@ parametersSchema:
 	])
 
 rules:
+    - Sfp\PHPStan\Psr\Log\Rules\ContextKeyPlaceHolderRule
     - Sfp\PHPStan\Psr\Log\Rules\NonEmptyStringKeyRule
     - Sfp\PHPStan\Psr\Log\Rules\PlaceHolderInMessageRule
 

--- a/src/Rules/ContextKeyPlaceHolderRule.php
+++ b/src/Rules/ContextKeyPlaceHolderRule.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sfp\PHPStan\Psr\Log\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\ObjectType;
+
+use function assert;
+use function count;
+use function implode;
+use function in_array;
+use function preg_match_all;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
+final class ContextKeyPlaceHolderRule implements Rule
+{
+    private const ERROR_MISSED_CONTEXT = 'Parameter $context of logger method Psr\Log\LoggerInterface::%s() is required, when placeholder braces exists - %s';
+    private const ERROR_MISSED_KEY     = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() has placeholder braces, but context key is not found against them. - %s';
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $calledOnType = $scope->getType($node->var);
+        if (! (new ObjectType('Psr\Log\LoggerInterface'))->isSuperTypeOf($calledOnType)->yes()) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+        if (count($args) === 0) {
+            return [];
+        }
+
+        $methodName = $node->name->toLowerString();
+
+        $contextArgumentNo = 1;
+        if ($methodName === 'log') {
+            if (
+                count($args) < 2
+                || ! $args[0]->value instanceof Node\Scalar\String_
+            ) {
+                return [];
+            }
+
+            $contextArgumentNo = 2;
+        } elseif (! in_array($methodName, LogLevelListInterface::LOGGER_LEVEL_METHODS)) {
+            return [];
+        }
+
+        $message = $args[$contextArgumentNo - 1];
+        if (! $message->value instanceof Node\Scalar\String_) {
+            return [];
+        }
+
+        $matched = preg_match_all('#{([A-Za-z0-9_\.]+?)}#', $message->value->value, $matches);
+
+        if ($matched === 0 || $matched === false) {
+            return [];
+        }
+
+        if (! isset($args[$contextArgumentNo])) {
+            return [sprintf(self::ERROR_MISSED_CONTEXT, $methodName, implode(',', $matches[0]))];
+        }
+
+        $context = $args[$contextArgumentNo];
+
+        return self::contextDoesNotHavePlaceholderKey($context, $methodName, $matches[0], $matches[1]);
+    }
+
+    /**
+     * @phpstan-param non-empty-array<string> $placeHolders
+     */
+    private static function contextDoesNotHavePlaceholderKey(Node\Arg $context, string $methodName, array $braces, array $placeHolders): array
+    {
+        $contextKeys = self::getContextKeys($context);
+        foreach ($placeHolders as $i => $placeholder) {
+            if (in_array($placeholder, $contextKeys, true)) {
+                unset($braces[$i]);
+            }
+        }
+
+        if (count($braces) === 0) {
+            return [];
+        }
+
+        return [sprintf(self::ERROR_MISSED_KEY, $methodName, implode(',', $braces))];
+    }
+
+    private static function getContextKeys(Node\Arg $context): array
+    {
+        if (! $context->value instanceof Node\Expr\Array_) {
+            return [];
+        }
+
+        if (count($context->value->items) === 0) {
+            return [];
+        }
+
+        $keys = [];
+        foreach ($context->value->items as $item) {
+            assert($item instanceof Node\Expr\ArrayItem);
+
+            if (isset($item->key->value)) {
+                $keys[] = $item->key->value;
+            }
+        }
+
+        return $keys;
+    }
+}

--- a/src/Rules/ContextKeyPlaceHolderRule.php
+++ b/src/Rules/ContextKeyPlaceHolderRule.php
@@ -13,6 +13,7 @@ use function assert;
 use function count;
 use function implode;
 use function in_array;
+use function is_string;
 use function preg_match_all;
 use function sprintf;
 
@@ -82,7 +83,9 @@ final class ContextKeyPlaceHolderRule implements Rule
     }
 
     /**
-     * @phpstan-param non-empty-array<string> $placeHolders
+     * @phpstan-param list<string> $braces
+     * @phpstan-param list<string> $placeHolders
+     * @phpstan-return list<string>
      */
     private static function contextDoesNotHavePlaceholderKey(Node\Arg $context, string $methodName, array $braces, array $placeHolders): array
     {
@@ -100,6 +103,9 @@ final class ContextKeyPlaceHolderRule implements Rule
         return [sprintf(self::ERROR_MISSED_KEY, $methodName, implode(',', $braces))];
     }
 
+    /**
+     * @phpstan-return list<string>
+     */
     private static function getContextKeys(Node\Arg $context): array
     {
         if (! $context->value instanceof Node\Expr\Array_) {
@@ -113,8 +119,7 @@ final class ContextKeyPlaceHolderRule implements Rule
         $keys = [];
         foreach ($context->value->items as $item) {
             assert($item instanceof Node\Expr\ArrayItem);
-
-            if (isset($item->key->value)) {
+            if (isset($item->key->value) && is_string($item->key->value)) {
                 $keys[] = $item->key->value;
             }
         }

--- a/test/Rules/ContextKeyPlaceHolderRuleTest.php
+++ b/test/Rules/ContextKeyPlaceHolderRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SfpTest\PHPStan\Psr\Log\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Sfp\PHPStan\Psr\Log\Rules\ContextKeyPlaceHolderRule;
+
+/**
+ * @implements RuleTestCase<ContextKeyPlaceHolderRule>
+ */
+final class ContextKeyPlaceHolderRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ContextKeyPlaceHolderRule();
+    }
+
+    /** @test */
+    public function testProcessNode(): void
+    {
+        $this->analyse([__DIR__ . '/data/contextKeyPlaceHolder.php'], [
+            'missing context'   => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::info() is required, when placeholder braces exists - {nonContext}',
+                17,
+            ],
+            'empty array'       => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has placeholder braces, but context key is not found against them. - {empty}',
+                18,
+            ],
+            'notMatched'        => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has placeholder braces, but context key is not found against them. - {notMatched}',
+                19,
+            ],
+            'many placeholders' => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has placeholder braces, but context key is not found against them. - {notMatched1},{notMatched2}',
+                20,
+            ],
+            'log method'        => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::log() has placeholder braces, but context key is not found against them. - {notMatched}',
+                21,
+            ],
+        ]);
+    }
+}

--- a/test/Rules/data/contextKeyPlaceHolder.php
+++ b/test/Rules/data/contextKeyPlaceHolder.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+function main(Psr\Log\LoggerInterface $logger, string $m): void
+{
+    // ignore
+    $logger->info('foo', ['ok' => "a"]);
+    $logger->info($m, ['ok' => "a"]);
+    // valid
+    $logger->info('message is {valid1_.} ..', ['valid1_.' => 'OK']);
+    $logger->info('message is {valid2_.} ..', ['valid1_.' => 'OK', 'valid2_.' => 'OK']);
+    // ignore
+    $logger->info('message has { invalid placeholder} .');
+    $logger->info('message has { invalid placeholder} .', [' invalid placeholder' => 'bar']);
+
+    $logger->info('message has {nonContext} .');
+    $logger->info('message has {empty} .', []);
+    $logger->info('message has {notMatched} .', ['foo' => 'bar']);
+    $logger->info('message has {notMatched1} , {matched1} , {notMatched2} .', ['matched1' => 'bar']);
+    $logger->log('info', 'message has {notMatched} .', ['foo' => 'bar']);
+}


### PR DESCRIPTION
fixes #13

### example

```php
  $this->logger->info('message has {nonContext} .');
  $this->logger->info('message has {empty} .', []);
  $this->logger->info('message has {notMatched} .', ['foo' => 'bar']);
  $this->logger->info('message has {notMatched1} , {matched1} , {notMatched2} .', ['matched1' => 'bar']);
  $this->logger->log('info', 'message has {notMatched} .', ['foo' => 'bar']);
```

would reports

```
  58     Parameter $context of logger method Psr\Log\LoggerInterface::info() is required, when placeholder braces exists - {nonContext}
  59     Parameter $message of logger method Psr\Log\LoggerInterface::info() has placeholder braces, but context key is not found against them. - {empty}
  60     Parameter $message of logger method Psr\Log\LoggerInterface::info() has placeholder braces, but context key is not found against them. - {notMatched}
  61     Parameter $message of logger method Psr\Log\LoggerInterface::info() has placeholder braces, but context key is not found against them. - {notMatched1},{notMatched2}
  62     Parameter $message of logger method Psr\Log\LoggerInterface::log() has placeholder braces, but context key is not found against them. - {notMatched}
```
