### PR TITLE
using `Scope::getType()` to enable support any argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor
-/.phpcs-cache
-/.phpunit.result.cache
 /composer.lock
+/.phpcs-cache
+/.phpunit.cache
+/.phpunit.result.cache
 
 /example/vendor

--- a/src/Rules/ContextRequireExceptionKeyRule.php
+++ b/src/Rules/ContextRequireExceptionKeyRule.php
@@ -16,7 +16,6 @@ use Throwable;
 use function assert;
 use function count;
 use function in_array;
-use function is_string;
 use function sprintf;
 
 /**
@@ -134,27 +133,14 @@ class ContextRequireExceptionKeyRule implements Rule
 
     private static function contextDoesNotHaveExceptionKey(Node\Arg $context, Scope $scope): bool
     {
-        if (! $context->value instanceof Node\Expr\Array_) {
-            if ($context->value instanceof Node\Expr\Variable) {
-                assert(is_string($context->value->name));
-                $contextVariable = $scope->getVariableType($context->value->name);
-                if (
-                    $contextVariable instanceof ArrayType
-                    && $contextVariable->hasOffsetValueType(new ConstantStringType('exception'))->yes()
-                ) {
-                    return false;
-                }
+        $type = $scope->getType($context->value);
+        if ($type instanceof ArrayType) {
+            if ($type->hasOffsetValueType(new ConstantStringType('exception'))->yes()) {
+                return false;
             }
             return true;
         }
 
-        foreach ($context->value->items as $item) {
-            assert($item instanceof Node\Expr\ArrayItem);
-            if ($item->key instanceof Node\Scalar\String_ && $item->key->value === 'exception') {
-                return false;
-            }
-        }
-
-        return true;
+        return false;
     }
 }

--- a/test/Rules/ContextRequireExceptionKeyRuleTest.php
+++ b/test/Rules/ContextRequireExceptionKeyRuleTest.php
@@ -57,6 +57,14 @@ final class ContextRequireExceptionKeyRuleTest extends RuleTestCase
                 'Parameter $context of logger method Psr\Log\LoggerInterface::critical() requires \'exception\' key. Current scope has Throwable variable - $exception2',
                 37,
             ],
+            'after array_merge'             => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::critical() requires \'exception\' key. Current scope has Throwable variable - $exception2',
+                40,
+            ],
+            'after array plus'              => [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::critical() requires \'exception\' key. Current scope has Throwable variable - $exception2',
+                41,
+            ],
         ]);
     }
 }

--- a/test/Rules/OtherLoggerInterface.php
+++ b/test/Rules/OtherLoggerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SfpTest\PHPStan\Psr\Log\Rules;
+
+interface OtherLoggerInterface
+{
+    public function critical(string $message): void;
+}

--- a/test/Rules/data/contextRequireExceptionKey.php
+++ b/test/Rules/data/contextRequireExceptionKey.php
@@ -35,14 +35,23 @@ function main(Psr\Log\LoggerInterface $logger, OtherLoggerInterface $otherLogger
         $logger->critical('foo', $context);
         $context = ['foo' => 'FOO', 'bar' => 'BAR']; // to check offset variable
         $logger->critical('foo', $context);
+
+        // ng
+        $logger->critical('foo', array_merge(['foo' => 1], ['exception2' => $exception2]));
+        $logger->critical('foo', ['foo' => 1] + ['exception2' => $exception2]);
+        $logger->critical('foo', returnMixedArray());
         // ok
         $context = ['foo' => 'bar', 'exception' => $exception2]; // to check offset variable
         $logger->critical('foo', $context);
         $context = ['exception' => $exception2];
         $logger->critical('foo', $context);
+        // ok
+        $logger->critical('foo', array_merge(['foo' => 1], ['exception' => $exception2]));
+        $logger->critical('foo', ['foo' => 1] + ['exception' => $exception2]);
 
         // Todo - handle function return type
-        $logger->log(determineLogLevel(), 'foo'); // currently ignore
+        $logger->log(determineLogLevel(), 'foo');
+        $logger->critical('foo', returnExceptionHasArray()); // returnExceptionHasArray would be ErrorType
 
         // ok
         $logger->critical("foo", ['exception' => $exception2]);
@@ -65,3 +74,14 @@ function determineLogLevel(): string
     return 'alert';
 }
 
+/** @return array<mixed> */
+function returnMixedArray() : array
+{
+    return ['exception' => new stdClass()];
+}
+
+/** @return array{exception: \Throwable} */
+function returnExceptionHasArray() : array
+{
+    return ['exception' => new \Exception];
+}

--- a/test/Rules/data/contextRequireExceptionKey.php
+++ b/test/Rules/data/contextRequireExceptionKey.php
@@ -39,7 +39,6 @@ function main(Psr\Log\LoggerInterface $logger, OtherLoggerInterface $otherLogger
         // ng
         $logger->critical('foo', array_merge(['foo' => 1], ['exception2' => $exception2]));
         $logger->critical('foo', ['foo' => 1] + ['exception2' => $exception2]);
-        $logger->critical('foo', returnMixedArray());
         // ok
         $context = ['foo' => 'bar', 'exception' => $exception2]; // to check offset variable
         $logger->critical('foo', $context);
@@ -51,6 +50,7 @@ function main(Psr\Log\LoggerInterface $logger, OtherLoggerInterface $otherLogger
 
         // Todo - handle function return type
         $logger->log(determineLogLevel(), 'foo');
+        $logger->critical('foo', returnMixedArray());
         $logger->critical('foo', returnExceptionHasArray()); // returnExceptionHasArray would be ErrorType
 
         // ok


### PR DESCRIPTION

```php
        // ng
        $logger->critical('foo', array_merge(['foo' => 1], ['exception2' => $exception2]));
        $logger->critical('foo', ['foo' => 1] + ['exception2' => $exception2]);
```

```php
        // ok
        $logger->critical('foo', array_merge(['foo' => 1], ['exception' => $exception2]));
        $logger->critical('foo', ['foo' => 1] + ['exception' => $exception2]);
```