### PR TITLE
Add MessageMustBeStatic Rule

### DIFF
--- a/example/src/Example.php
+++ b/example/src/Example.php
@@ -7,6 +7,8 @@ namespace src;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
+use function sprintf;
+
 class Example
 {
     /** @var LoggerInterface */
@@ -60,5 +62,15 @@ class Example
         $this->logger->info('message has {notMatched} .', ['foo' => 'bar']);
         $this->logger->info('message has {notMatched1} , {matched1} , {notMatched2} .', ['matched1' => 'bar']);
         $this->logger->log('info', 'message has {notMatched} .', ['foo' => 'bar']);
+    }
+
+    public function messageNotStaticString(string $var): void
+    {
+        $this->logger->info("Message contains {$var} variable");
+        $this->logger->info("Message contains $var variable");
+        $this->logger->info("Message contains " . $var . " variable");
+        $this->logger->info('Message contains ' . $var . ' variable');
+        $this->logger->info(sprintf('Message contains %s variable', $var));
+        $this->logger->log('info', sprintf('Message contains %s variable', $var));
     }
 }

--- a/rules.neon
+++ b/rules.neon
@@ -3,19 +3,20 @@ parameters:
         reportContextExceptionLogLevel: 'debug'
 
 parametersSchema:
-	sfpPsrLog: structure([
-		reportContextExceptionLogLevel: schema(string(), nullable())
-	])
+    sfpPsrLog: structure([
+        reportContextExceptionLogLevel: schema(string(), nullable())
+    ])
 
 rules:
     - Sfp\PHPStan\Psr\Log\Rules\ContextKeyPlaceHolderRule
     - Sfp\PHPStan\Psr\Log\Rules\ContextKeyNonEmptyStringRule
+    - Sfp\PHPStan\Psr\Log\Rules\MessageMustBeStaticRule
     - Sfp\PHPStan\Psr\Log\Rules\PlaceHolderInMessageRule
 
 services:
-	-
-		class: Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
-		arguments:
-			reportContextExceptionLogLevel: %sfpPsrLog.reportContextExceptionLogLevel%
-		tags:
-			- phpstan.rules.rule
+    -
+        class: Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
+        arguments:
+            reportContextExceptionLogLevel: %sfpPsrLog.reportContextExceptionLogLevel%
+        tags:
+            - phpstan.rules.rule

--- a/src/Rules/MessageMustBeStaticRule.php
+++ b/src/Rules/MessageMustBeStaticRule.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sfp\PHPStan\Psr\Log\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ObjectType;
+
+use function count;
+use function get_class;
+use function in_array;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
+final class MessageMustBeStaticRule implements Rule
+{
+    private const ERROR_MESSAGE_NOT_STATIC = 'Parameter $message of logger method Psr\Log\LoggerInterface::%s() is not a static string - %s';
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    /**
+     * @throws ShouldNotHappenException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier) {
+            // @codeCoverageIgnoreStart
+            return []; // @codeCoverageIgnoreEnd
+        }
+
+        $calledOnType = $scope->getType($node->var);
+        if (! (new ObjectType('Psr\Log\LoggerInterface'))->isSuperTypeOf($calledOnType)->yes()) {
+            // @codeCoverageIgnoreStart
+            return []; // @codeCoverageIgnoreEnd
+        }
+
+        $args = $node->getArgs();
+        if (count($args) === 0) {
+            // @codeCoverageIgnoreStart
+            return []; // @codeCoverageIgnoreEnd
+        }
+
+        $methodName = $node->name->toLowerString();
+
+        $messageArgumentNo = 0;
+        if ($methodName === 'log') {
+            if (
+                count($args) < 2
+                || ! $args[0]->value instanceof Node\Scalar\String_
+            ) {
+                // @codeCoverageIgnoreStart
+                return []; // @codeCoverageIgnoreEnd
+            }
+
+            $messageArgumentNo = 1;
+        } elseif (! in_array($methodName, LogLevelListInterface::LOGGER_LEVEL_METHODS)) {
+            // @codeCoverageIgnoreStart
+            return []; // @codeCoverageIgnoreEnd
+        }
+
+        $message = $args[$messageArgumentNo];
+
+        if (! $message->value instanceof Node\Scalar\String_) {
+            return [sprintf(self::ERROR_MESSAGE_NOT_STATIC, $methodName, get_class($message->value))];
+        }
+
+        return [];
+    }
+}

--- a/test/Rules/MessageMustBeStaticRuleTest.php
+++ b/test/Rules/MessageMustBeStaticRuleTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SfpTest\PHPStan\Psr\Log\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Sfp\PHPStan\Psr\Log\Rules\MessageMustBeStaticRule;
+use Sfp\PHPStan\Psr\Log\Rules\PlaceHolderInMessageRule;
+
+/**
+ * @implements RuleTestCase<PlaceHolderInMessageRule>
+ * @covers \Sfp\PHPStan\Psr\Log\Rules\PlaceHolderInMessageRule
+ */
+final class MessageMustBeStaticRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new MessageMustBeStaticRule();
+    }
+
+    /**
+     * @test
+     */
+    public function testProcessNode(): void
+    {
+        $this->analyse([__DIR__ . '/data/messageMustBeStatic.php'], [
+            'variable'                            => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() is not a static string - PhpParser\Node\Expr\Variable',
+                10,
+            ],
+            'double quote escaped with braces'    => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() is not a static string - PhpParser\Node\Scalar\Encapsed',
+                11,
+            ],
+            'double quote escaped without braces' => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() is not a static string - PhpParser\Node\Scalar\Encapsed',
+                12,
+            ],
+            'concat double quote'                 => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() is not a static string - PhpParser\Node\Expr\BinaryOp\Concat',
+                13,
+            ],
+            'concat single quote'                 => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() is not a static string - PhpParser\Node\Expr\BinaryOp\Concat',
+                14,
+            ],
+            'function call'                       => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() is not a static string - PhpParser\Node\Expr\FuncCall',
+                15,
+            ],
+            'call log() method'                   => [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::log() is not a static string - PhpParser\Node\Expr\Variable',
+                17,
+            ],
+        ]);
+    }
+}

--- a/test/Rules/data/messageMustBeStatic.php
+++ b/test/Rules/data/messageMustBeStatic.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+function main(Psr\Log\LoggerInterface $logger, string $m): void
+{
+    // valid
+    $logger->info('message is valid');
+
+    $logger->info($m);
+    $logger->info("Message contains {$m} variable");
+    $logger->info("Message contains $m variable");
+    $logger->info("Message contains " . $m . " variable");
+    $logger->info('Message contains ' . $m . ' variable');
+    $logger->info(sprintf('Message contains %s variable', $m));
+
+    $logger->log('info', $m);
+}


### PR DESCRIPTION
Based on the [PSR-3 Meta Document](https://www.php-fig.org/psr/psr-3/meta/#static-log-messages) released by PHP-FIG:

> [...] It is the intent of this specification that the message passed to a logging method always be a static value. Any context-specific variability (such as a username, timestamp, or other information) should be provided via the $context array only, and the string should use a placeholder to reference it.
>
> The intent of this design is twofold. One, the message is then readily available to translation systems to create localized versions of log messages. Two, context-specific data may contain user input, and thus requires escaping. That escaping will be necessarily different if the log message is stored in a database for later rendering in HTML, serialized to JSON, serialized to a syslog message string, etc. It is the responsibility of the logging implementation to ensure that `$context` data that is shown to the user is appropriately escaped.