### PR TITLE
Update sfp-stubs-psr-log requiment version - ^1.0.1 || ^2 || ^3.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
         "MIT"
     ],
     "require": {
-        "php":"^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
         "phpstan/phpstan": "^1.10",
-        "struggle-for-php/sfp-stubs-psr-log": "^1 || ^2 || ^3"
+        "struggle-for-php/sfp-stubs-psr-log": "^1.0.1 || ^2 || ^3.0.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^2.0.0",


### PR DESCRIPTION
This updates is needed for,

- [v1] php requirement should be >=5.3.0 
    - https://github.com/struggle-for-php/sfp-stubs-psr-log/pull/19

- [v3] Missing return void 
    - https://github.com/struggle-for-php/sfp-stubs-psr-log/pull/18