### PR TITLE
Update README to show error identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ This package provides the following rules.
 
 > Placeholder names SHOULD be composed only of the characters A-Z, a-z, 0-9, underscore _, and period .
 
-#### _error identifier:_ `sfp-psr-log.placeHolderInMessageInvalidChar`
+#### `sfp-psr-log.placeHolderInMessageInvalidChar`
 
 * reports when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
   * :x: `$logger->info('message are {foo-hyphen}');`
 
-#### _error identifier:_ `sfp-psr-log.placeHolderInMessageDoubleBraches`
+#### `sfp-psr-log.placeHolderInMessageDoubleBraches`
 
 * reports when double braces pair `{{` `}}` are used.
 
@@ -39,30 +39,30 @@ This package provides the following rules.
 
 > Placeholder names MUST correspond to keys in the context array.
 
-#### _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedContext`
+#### `sfp-psr-log.contextKeyPlaceHolderMissedContext`
 
 * reports when placeholder exists in message, but `$context` parameter is missed.
   * :x: `$logger->info('message has {nonContext} .');`
 
-#### _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedKey`
+#### `sfp-psr-log.contextKeyPlaceHolderMissedKey`
 
 * reports when placeholder exists in message, but key in `$context` does not exist against them.
   * :x: `$logger->info('user {user_id} gets an error {error} .', ['user_id' => $user_id]);`
 
 ### ContextKeyNonEmptyStringRule
 
-`NOTES: PSR-3 has no provisions for array keys, but this is useful in many cases`
+*NOTES: PSR-3 has no provisions for array keys, but this is useful in many cases*
 
-#### _error identifier:_ `sfp-psr-log.contextKeyNonEmptyString`
+#### `sfp-psr-log.contextKeyNonEmptyString`
 
 * reports when context key is not **non-empty-string**.
   * :x: `[123 => 'foo']`, `['' => 'bar']`, `['baz']`
 
 ### ContextRequireExceptionKeyRule
 
-`NOTES: This is not a rule for PSR-3, but provides best practices.`
+*NOTES: This is not a rule for PSR-3, but provides best practices.*
 
-#### _error identifier:_ `sfp-psr-log.contextRequireExceptionKey`
+#### `sfp-psr-log.contextRequireExceptionKey`
 
 * It forces `exception` key into context parameter when current scope has `\Throwable` object.
 

--- a/README.md
+++ b/README.md
@@ -19,33 +19,41 @@ See [psr/log stub](https://github.com/struggle-for-php/sfp-stubs-psr-log) reposi
 
 ## Rules
 
-This package provides the following rules:
+This package provides the following rules.
 
 ### ContextKeyNonEmptyStringRule
 
-* This rule reports an error when context key is not **non-empty-string**.
-  * _error identifier:_ `sfp-psr-log.contextKeyNonEmptyString`
+#### _error identifier:_ `sfp-psr-log.contextKeyNonEmptyString`
+
+* reports when context key is not **non-empty-string**.
   * :x: `[123 => 'foo']`, `['' => 'bar']`, `['baz']`
 
 ### PlaceHolderInMessageRule
 
-* This rule reports an error when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
-  * _error identifier:_ `sfp-psr-log.placeHolderInMessageInvalidChar`
-* This rules also reports an error when double braces pair `{{` `}}` are used.
-  * _error identifier:_ `sfp-psr-log.placeHolderInMessageDoubleBraches`
+#### _error identifier:_ `sfp-psr-log.placeHolderInMessageInvalidChar`
+
+* reports when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
+
+#### _error identifier:_ `sfp-psr-log.placeHolderInMessageDoubleBraches`
+
+* reports when double braces pair `{{` `}}` are used.
 
 ### ContextKeyPlaceHolderRule
 
-* This rule reports an error when placeholder exists in message, but `$context` parameter is missed.
-  * _error identifier:_ `sfp-psr-log.contextKeyPlaceHolder-missedContext`
-* This rule reports an error when placeholder exists in message, but key in `$context` does not exist against them.
-  * _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedKey`
+#### _error identifier:_ `sfp-psr-log.contextKeyPlaceHolder-missedContext`
+
+* reports when placeholder exists in message, but `$context` parameter is missed.
+
+#### _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedKey`
+
+* reports when placeholder exists in message, but key in `$context` does not exist against them.
   * :x: `$logger->info(''user {user_id} gets an error {error} .', ['user_id' => $user_id]);`
 
 ### ContextRequireExceptionKeyRule
 
+#### _error identifier:_ `sfp-psr-log.contextRequireExceptionKey`
+
 * It forces `exception` key into context parameter when current scope has `\Throwable` object.
-  * _error identifier:_ `sfp-psr-log.contextRequireExceptionKey`
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 * [PHPStan](https://phpstan.org/)
 * [PSR-3: Logger Interface - PHP-FIG](https://www.php-fig.org/psr/psr-3/)
 
-
 ## Stubs
+
 This extension depends on our psr/log stub to serve strictness.
 
-eg.
- * `@param LogLevel::*  $level` at `log()` method
- * `@param array{exception?: \Throwable} $context` 
+* eg.
+  * `@param LogLevel::*  $level` at `log()` method
+  * `@param array{exception?: \Throwable} $context`
 
 See [psr/log stub](https://github.com/struggle-for-php/sfp-stubs-psr-log) repository page to get more detail.
 
@@ -22,26 +22,30 @@ See [psr/log stub](https://github.com/struggle-for-php/sfp-stubs-psr-log) reposi
 This package provides the following rules:
 
 ### ContextKeyNonEmptyStringRule
+
 * This rule reports an error when context key is not **non-empty-string**.
-  * <i>error identifier:</i> `sfp-psr-log.contextKeyNonEmptyString`
+  * _error identifier:_ `sfp-psr-log.contextKeyNonEmptyString`
   * :x: `[123 => 'foo']`, `['' => 'bar']`, `['baz']`
 
 ### PlaceHolderInMessageRule
+
 * This rule reports an error when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
-  * <i>error identifier:</i> `sfp-psr-log.placeHolderInMessageInvalidChar`
+  * _error identifier:_ `sfp-psr-log.placeHolderInMessageInvalidChar`
 * This rules also reports an error when double braces pair `{{` `}}` are used.
-  * <i>error identifier:</i> `sfp-psr-log.placeHolderInMessageDoubleBraches`
+  * _error identifier:_ `sfp-psr-log.placeHolderInMessageDoubleBraches`
 
 ### ContextKeyPlaceHolderRule
+
 * This rule reports an error when placeholder exists in message, but `$context` parameter is missed.
-  * <i>error identifier:</i> `sfp-psr-log.contextKeyPlaceHolder-missedContext`
+  * _error identifier:_ `sfp-psr-log.contextKeyPlaceHolder-missedContext`
 * This rule reports an error when placeholder exists in message, but key in `$context` does not exist against them.
-  * <i>error identifier:</i> `sfp-psr-log.contextKeyPlaceHolderMissedKey`
+  * _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedKey`
   * :x: `$logger->info(''user {user_id} gets an error {error} .', ['user_id' => $user_id]);`
 
 ### ContextRequireExceptionKeyRule
+
 * It forces `exception` key into context parameter when current scope has `\Throwable` object.
-  * <i>error identifier:</i> `sfp-psr-log.contextRequireExceptionKey`
+  * _error identifier:_ `sfp-psr-log.contextRequireExceptionKey`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,12 @@ This package provides the following rules.
 
 > Placeholder names SHOULD be composed only of the characters A-Z, a-z, 0-9, underscore _, and period .
 
-#### `sfp-psr-log.placeHolderInMessageInvalidChar`
-
 * reports when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
   * :x: `$logger->info('message are {foo-hyphen}');`
-
-#### `sfp-psr-log.placeHolderInMessageDoubleBraches`
+  * :mag_right: `sfp-psr-log.placeHolderInMessageInvalidChar`
 
 * reports when double braces pair `{{` `}}` are used.
+  * :mag_right: `sfp-psr-log.placeHolderInMessageDoubleBraches`
 
 ### ContextKeyPlaceHolderRule
 
@@ -51,7 +49,8 @@ This package provides the following rules.
 
 ### ContextKeyNonEmptyStringRule
 
-**NOTES: PSR-3 has no provisions for array keys, but this is useful in many cases.**
+> [!NOTE]
+> PSR-3 has no provisions for array keys, but this is useful in many cases.**
 
 #### `sfp-psr-log.contextKeyNonEmptyString`
 
@@ -60,7 +59,8 @@ This package provides the following rules.
 
 ### ContextRequireExceptionKeyRule
 
-**NOTES: This is not a rule for PSR-3, but provides best practices.**
+> [!NOTE]
+> This is not a rule for PSR-3, but provides best practices.**
 
 #### `sfp-psr-log.contextRequireExceptionKey`
 

--- a/README.md
+++ b/README.md
@@ -28,19 +28,18 @@ This package provides the following rules.
 
 * reports when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
   * :x: `$logger->info('message are {foo-hyphen}');`
-  * :mag_right: `sfp-psr-log.placeHolderInMessageInvalidChar`
+    * :pushpin: _error identifier:_ `sfp-psr-log.placeHolderInMessageInvalidChar`
 
 * reports when double braces pair `{{` `}}` are used.
-  * :mag_right: `sfp-psr-log.placeHolderInMessageDoubleBraches`
+  * :pushpin: _error identifier:_ `sfp-psr-log.placeHolderInMessageDoubleBraches`
 
 ### ContextKeyPlaceHolderRule
 
 > Placeholder names MUST correspond to keys in the context array.
 
-#### `sfp-psr-log.contextKeyPlaceHolderMissedContext`
-
 * reports when placeholder exists in message, but `$context` parameter is missed.
   * :x: `$logger->info('message has {nonContext} .');`
+    * :pushpin: _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedContext`
 
 #### `sfp-psr-log.contextKeyPlaceHolderMissedKey`
 
@@ -50,7 +49,7 @@ This package provides the following rules.
 ### ContextKeyNonEmptyStringRule
 
 > [!NOTE]
-> PSR-3 has no provisions for array keys, but this is useful in many cases.**
+> PSR-3 has no provisions for array keys, but this is useful in many cases.
 
 #### `sfp-psr-log.contextKeyNonEmptyString`
 
@@ -60,7 +59,7 @@ This package provides the following rules.
 ### ContextRequireExceptionKeyRule
 
 > [!NOTE]
-> This is not a rule for PSR-3, but provides best practices.**
+> This is not a rule for PSR-3, but provides best practices.
 
 #### `sfp-psr-log.contextRequireExceptionKey`
 

--- a/README.md
+++ b/README.md
@@ -24,46 +24,81 @@ This package provides the following rules.
 
 ### PlaceHolderInMessageRule
 
-> Placeholder names SHOULD be composed only of the characters A-Z, a-z, 0-9, underscore _, and period .
+| :pushpin: _error identifier_ |
+| --- |
+| sfp-psr-log.placeHolderInMessageInvalidChar |
 
-* reports when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
-  * :x: `$logger->info('message are {foo-hyphen}');`
-    * :pushpin: _error identifier:_ `sfp-psr-log.placeHolderInMessageInvalidChar`
+* reports when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`[^a1]
+
+[^a1]: [Placeholder names SHOULD be composed only of the characters A-Z, a-z, 0-9, underscore _, and period .](https://www.php-fig.org/psr/psr-3/#12-message)
+
+```php
+// bad
+$logger->info('message are {foo-hyphen}');
+```
+
+| :pushpin: _error identifier_ |
+| --- |
+| sfp-psr-log.placeHolderInMessageDoubleBraches |
 
 * reports when double braces pair `{{` `}}` are used.
-  * :pushpin: _error identifier:_ `sfp-psr-log.placeHolderInMessageDoubleBraches`
+
+```php
+// bad
+$logger->info('message are {{foo}}');
+```
 
 ### ContextKeyPlaceHolderRule
 
-> Placeholder names MUST correspond to keys in the context array.
+| :pushpin: _error identifier_ |
+| --- |
+| sfp-psr-log.contextKeyPlaceHolderMissedContext |
 
-* reports when placeholder exists in message, but `$context` parameter is missed.
-  * :x: `$logger->info('message has {nonContext} .');`
-    * :pushpin: _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedContext`
+* reports when placeholder exists in message, but `$context` parameter is missed.[^b1]
 
-#### `sfp-psr-log.contextKeyPlaceHolderMissedKey`
+[^b1]: Placeholder names MUST correspond to keys in the context array.
+
+```php
+// bad
+$logger->info('message has {nonContext} .');
+```
+
+| :pushpin: _error identifier_ |
+| --- |
+| sfp-psr-log.contextKeyPlaceHolderMissedKey |
 
 * reports when placeholder exists in message, but key in `$context` does not exist against them.
-  * :x: `$logger->info('user {user_id} gets an error {error} .', ['user_id' => $user_id]);`
+
+```php
+// bad
+$logger->info('user {user_id} gets an error {error} .', ['user_id' => $user_id]);
+```
 
 ### ContextKeyNonEmptyStringRule
 
-> [!NOTE]
-> PSR-3 has no provisions for array keys, but this is useful in many cases.
-
-#### `sfp-psr-log.contextKeyNonEmptyString`
+| :pushpin: _error identifier_ |
+| --- |
+| sfp-psr-log.contextKeyNonEmptyString |
 
 * reports when context key is not **non-empty-string**.
-  * :x: `[123 => 'foo']`, `['' => 'bar']`, `['baz']`
+
+```php
+[123 => 'foo']`, `['' => 'bar']`, `['baz']
+```
+
+> [!NOTE]
+> PSR-3 has no provisions for array key's types, but this is useful in many cases.
 
 ### ContextRequireExceptionKeyRule
 
-> [!NOTE]
-> This is not a rule for PSR-3, but provides best practices.
-
-#### `sfp-psr-log.contextRequireExceptionKey`
+| :pushpin: _error identifier_ |
+| --- |
+| sfp-psr-log.contextRequireExceptionKey |
 
 * It forces `exception` key into context parameter when current scope has `\Throwable` object.
+
+> [!NOTE]
+> This is not a rule for along with PSR-3 specification, but provides best practices.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -7,24 +7,41 @@
 * [PHPStan](https://phpstan.org/)
 * [PSR-3: Logger Interface - PHP-FIG](https://www.php-fig.org/psr/psr-3/)
 
-This extension provides following features:
 
-* stubs
+## Stubs
+This extension depends on our psr/log stub to serve strictness.
 
-  * Deliver stubs to let PHPStan understand psr/log (PSR-3) strictly.
-  * >  Implementors MUST still verify that the 'exception' key is actually an Exception before using it as such, as it MAY contain anything.
-  * https://www.php-fig.org/psr/psr-3/#13-context
+eg.
+ * `@param LogLevel::*  $level` at `log()` method
+ * `@param array{exception?: \Throwable} $context` 
 
-It also contains this strict specific rules:
+See [psr/log stub](https://github.com/struggle-for-php/sfp-stubs-psr-log) repository page to get more detail.
 
-* ContextKeyNonEmptyStringRule
-  * context key should be string.
-* PlaceHolderInMessageRule
-  * placeholder in `$message` characters are `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
-* ContextKeyPlaceHolderRule
-  * When placeholder exists in message, checks keys in `$context` exists against them.
-* ContextRequireExceptionKeyRule
-  * It forces `exception` key into context parameter when current scope has Throwable object.
+## Rules
+
+This package provides the following rules:
+
+### ContextKeyNonEmptyStringRule
+* This rule reports an error when context key is not **non-empty-string**.
+  * <i>error identifier:</i> `sfp-psr-log.contextKeyNonEmptyString`
+  * :x: `[123 => 'foo']`, `['' => 'bar']`, `['baz']`
+
+### PlaceHolderInMessageRule
+* This rule reports an error when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
+  * <i>error identifier:</i> `sfp-psr-log.placeHolderInMessageInvalidChar`
+* This rules also reports an error when double braces pair `{{` `}}` are used.
+  * <i>error identifier:</i> `sfp-psr-log.placeHolderInMessageDoubleBraches`
+
+### ContextKeyPlaceHolderRule
+* This rule reports an error when placeholder exists in message, but `$context` parameter is missed.
+  * <i>error identifier:</i> `sfp-psr-log.contextKeyPlaceHolder-missedContext`
+* This rule reports an error when placeholder exists in message, but key in `$context` does not exist against them.
+  * <i>error identifier:</i> `sfp-psr-log.contextKeyPlaceHolderMissedKey`
+  * :x: `$logger->info(''user {user_id} gets an error {error} .', ['user_id' => $user_id]);`
+
+### ContextRequireExceptionKeyRule
+* It forces `exception` key into context parameter when current scope has `\Throwable` object.
+  * <i>error identifier:</i> `sfp-psr-log.contextRequireExceptionKey`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -47,69 +47,7 @@ This package provides the following rules:
 * It forces `exception` key into context parameter when current scope has `\Throwable` object.
   * _error identifier:_ `sfp-psr-log.contextRequireExceptionKey`
 
-## Installation
-
-To use this extension, require it in [Composer](https://getcomposer.org/):
-
-```bash
-composer require --dev struggle-for-php/sfp-phpstan-psr-log
-```
-
-If you also install [phpstan/extension-installer](https://github.com/phpstan/extension-installer) then you're all set.
-
-### Manual installation
-
-If you don't want to use `phpstan/extension-installer`, include extension.neon & rules.neon in your project's PHPStan config:
-
-```neon
-includes:
-    - vendor/struggle-for-php/sfp-phpstan-psr-log/extension.neon
-    - vendor/struggle-for-php/sfp-phpstan-psr-log/rules.neon
-```
-
-## Examples
-
-### stub - context 'exception' key is actually an Exception
-
-```php
-<?php
-
-use Psr\Log\LoggerInterface;
-
-class Foo
-{
-    /** @var LoggerInterface */
-    private $logger;
-
-    public function anyAction()
-    {
-        try {
-            // 
-        } catch (\Exception $e) {
-            $this->logger->error('error happen.', ['exception' => 'foo']);
-        }
-    }
-}
-```
-
-```sh
-$ ../vendor/bin/phpstan analyse
-Note: Using configuration file /tmp/your-project/phpstan.neon.
- 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
-
- ------ -------------------------------------------------------------
-  Line   Demo.php
- ------ -------------------------------------------------------------
-  15     Parameter #2 $context of method Psr\Log\LoggerInterface::error() expects array()|array('exception' => Exception), array('exception' => 'foo') given.
- ------ -------------------------------------------------------------
-
-
- [ERROR] Found 1 error
-```
-
-### ContextRequireExceptionKeyRule
-
-### Example
+#### Example
 
 ```php
 <?php
@@ -134,4 +72,24 @@ Note: Using configuration file /tmp/your-project/phpstan.neon.
 
 
  [ERROR] Found 1 error
+```
+
+## Installation
+
+To use this extension, require it in [Composer](https://getcomposer.org/):
+
+```bash
+composer require --dev struggle-for-php/sfp-phpstan-psr-log
+```
+
+If you also install [phpstan/extension-installer](https://github.com/phpstan/extension-installer) then you're all set.
+
+### Manual installation
+
+If you don't want to use `phpstan/extension-installer`, include extension.neon & rules.neon in your project's PHPStan config:
+
+```neon
+includes:
+    - vendor/struggle-for-php/sfp-phpstan-psr-log/extension.neon
+    - vendor/struggle-for-php/sfp-phpstan-psr-log/rules.neon
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This package provides the following rules.
 
 ### ContextKeyNonEmptyStringRule
 
-*NOTES: PSR-3 has no provisions for array keys, but this is useful in many cases*
+**NOTES: PSR-3 has no provisions for array keys, but this is useful in many cases.**
 
 #### `sfp-psr-log.contextKeyNonEmptyString`
 
@@ -60,7 +60,7 @@ This package provides the following rules.
 
 ### ContextRequireExceptionKeyRule
 
-*NOTES: This is not a rule for PSR-3, but provides best practices.*
+**NOTES: This is not a rule for PSR-3, but provides best practices.**
 
 #### `sfp-psr-log.contextRequireExceptionKey`
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This package provides the following rules.
 
 ### ContextKeyPlaceHolderRule
 
-#### _error identifier:_ `sfp-psr-log.contextKeyPlaceHolder-missedContext`
+#### _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedContext`
 
 * reports when placeholder exists in message, but `$context` parameter is missed.
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ This package provides the following rules.
 
 ### PlaceHolderInMessageRule
 
+> Placeholder names SHOULD be composed only of the characters A-Z, a-z, 0-9, underscore _, and period .
+
 | :pushpin: _error identifier_ |
 | --- |
 | sfp-psr-log.placeHolderInMessageInvalidChar |
 
-* reports when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`[^a1]
-
-[^a1]: [Placeholder names SHOULD be composed only of the characters A-Z, a-z, 0-9, underscore _, and period .](https://www.php-fig.org/psr/psr-3/#12-message)
+* reports when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
 
 ```php
 // bad
@@ -50,13 +50,13 @@ $logger->info('message are {{foo}}');
 
 ### ContextKeyPlaceHolderRule
 
+> Placeholder names MUST correspond to keys in the context array.
+
 | :pushpin: _error identifier_ |
 | --- |
 | sfp-psr-log.contextKeyPlaceHolderMissedContext |
 
-* reports when placeholder exists in message, but `$context` parameter is missed.[^b1]
-
-[^b1]: Placeholder names MUST correspond to keys in the context array.
+* reports when placeholder exists in message, but `$context` parameter is missed.
 
 ```php
 // bad
@@ -76,6 +76,9 @@ $logger->info('user {user_id} gets an error {error} .', ['user_id' => $user_id])
 
 ### ContextKeyNonEmptyStringRule
 
+> [!NOTE]
+> PSR-3 has no provisions for array keys, but this is useful in many cases.
+
 | :pushpin: _error identifier_ |
 | --- |
 | sfp-psr-log.contextKeyNonEmptyString |
@@ -83,22 +86,20 @@ $logger->info('user {user_id} gets an error {error} .', ['user_id' => $user_id])
 * reports when context key is not **non-empty-string**.
 
 ```php
+// bad
 [123 => 'foo']`, `['' => 'bar']`, `['baz']
 ```
 
-> [!NOTE]
-> PSR-3 has no provisions for array key's types, but this is useful in many cases.
-
 ### ContextRequireExceptionKeyRule
+
+> [!NOTE]
+> This is not a rule for along with PSR-3 specification, but provides best practices.
 
 | :pushpin: _error identifier_ |
 | --- |
 | sfp-psr-log.contextRequireExceptionKey |
 
 * It forces `exception` key into context parameter when current scope has `\Throwable` object.
-
-> [!NOTE]
-> This is not a rule for along with PSR-3 specification, but provides best practices.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 * [PHPStan](https://phpstan.org/)
 * [PSR-3: Logger Interface - PHP-FIG](https://www.php-fig.org/psr/psr-3/)
+* [PSR-3 Meta Document](https://www.php-fig.org/psr/psr-3/meta/)
 
 ## Stubs
 
@@ -21,18 +22,14 @@ See [psr/log stub](https://github.com/struggle-for-php/sfp-stubs-psr-log) reposi
 
 This package provides the following rules.
 
-### ContextKeyNonEmptyStringRule
-
-#### _error identifier:_ `sfp-psr-log.contextKeyNonEmptyString`
-
-* reports when context key is not **non-empty-string**.
-  * :x: `[123 => 'foo']`, `['' => 'bar']`, `['baz']`
-
 ### PlaceHolderInMessageRule
+
+> Placeholder names SHOULD be composed only of the characters A-Z, a-z, 0-9, underscore _, and period .
 
 #### _error identifier:_ `sfp-psr-log.placeHolderInMessageInvalidChar`
 
 * reports when placeholder in `$message` characters are **not**, `A-Z`, `a-z`, `0-9`, underscore `_`, and period `.`
+  * :x: `$logger->info('message are {foo-hyphen}');`
 
 #### _error identifier:_ `sfp-psr-log.placeHolderInMessageDoubleBraches`
 
@@ -40,16 +37,30 @@ This package provides the following rules.
 
 ### ContextKeyPlaceHolderRule
 
+> Placeholder names MUST correspond to keys in the context array.
+
 #### _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedContext`
 
 * reports when placeholder exists in message, but `$context` parameter is missed.
+  * :x: `$logger->info('message has {nonContext} .');`
 
 #### _error identifier:_ `sfp-psr-log.contextKeyPlaceHolderMissedKey`
 
 * reports when placeholder exists in message, but key in `$context` does not exist against them.
-  * :x: `$logger->info(''user {user_id} gets an error {error} .', ['user_id' => $user_id]);`
+  * :x: `$logger->info('user {user_id} gets an error {error} .', ['user_id' => $user_id]);`
+
+### ContextKeyNonEmptyStringRule
+
+`NOTES: PSR-3 has no provisions for array keys, but this is useful in many cases`
+
+#### _error identifier:_ `sfp-psr-log.contextKeyNonEmptyString`
+
+* reports when context key is not **non-empty-string**.
+  * :x: `[123 => 'foo']`, `['' => 'bar']`, `['baz']`
 
 ### ContextRequireExceptionKeyRule
+
+`NOTES: This is not a rule for PSR-3, but provides best practices.`
 
 #### _error identifier:_ `sfp-psr-log.contextRequireExceptionKey`
 

--- a/src/Rules/ContextKeyPlaceHolderRule.php
+++ b/src/Rules/ContextKeyPlaceHolderRule.php
@@ -83,7 +83,7 @@ final class ContextKeyPlaceHolderRule implements Rule
             return [
                 RuleErrorBuilder::message(
                     sprintf(self::ERROR_MISSED_CONTEXT, $methodName, implode(',', $matches[0]))
-                )->identifier('sfp-psr-log.contextKeyPlaceHolder-missedContext')->build(),
+                )->identifier('sfp-psr-log.contextKeyPlaceHolderMissedContext')->build(),
             ];
         }
 

--- a/test/Rules/PlaceHolderInMessageRuleTest.php
+++ b/test/Rules/PlaceHolderInMessageRuleTest.php
@@ -36,13 +36,18 @@ final class PlaceHolderInMessageRuleTest extends RuleTestCase
                 'See https://www.php-fig.org/psr/psr-3/#12-message',
             ],
             [
+                'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. But it includes invalid characters for placeholder. - {hyphen-hyphen}',
+                17, // invalid placeholder char
+                'See https://www.php-fig.org/psr/psr-3/#12-message',
+            ],
+            [
                 'Parameter $message of logger method Psr\Log\LoggerInterface::log() has braces. But it includes invalid characters for placeholder. - {&invalid&}',
-                17, // call log() method
+                18, // call log() method
                 'See https://www.php-fig.org/psr/psr-3/#12-message',
             ],
             [
                 'Parameter $message of logger method Psr\Log\LoggerInterface::info() has braces. But it includes invalid characters for placeholder. - {&a},{&b},{&c}',
-                18, // Many Invalid PlaceHolders
+                19, // Many Invalid PlaceHolders
                 'See https://www.php-fig.org/psr/psr-3/#12-message',
             ],
         ]);

--- a/test/Rules/data/contextKeyPlaceHolder.php
+++ b/test/Rules/data/contextKeyPlaceHolder.php
@@ -10,7 +10,7 @@ function main(Psr\Log\LoggerInterface $logger, string $m): void
     // valid
     $logger->info('message is {valid1_.} ..', ['valid1_.' => 'OK']);
     $logger->info('message is {valid2_.} ..', ['valid1_.' => 'OK', 'valid2_.' => 'OK']);
-    // ignore
+    // ignore - should be checked by PlaceHolderInMessageRule
     $logger->info('message has { invalid placeholder} .');
     $logger->info('message has { invalid placeholder} .', [' invalid placeholder' => 'bar']);
 

--- a/test/Rules/data/placeHolderInMessage.php
+++ b/test/Rules/data/placeHolderInMessage.php
@@ -14,6 +14,7 @@ function main(Psr\Log\LoggerInterface $logger, string $m): void
 
     $logger->info('message has {{doubleBrace}} .', ['doubleBrace' => 'bar']);
     $logger->info('message has { space } .', [' space ' => 'bar']);
+    $logger->info('message has {hyphen-hyphen} .', ['hyphen-hyphen' => 'bar']);
     $logger->log('info', 'message has {&invalid&} .', ['&invalid&' => 'bar']);
     $logger->info('message has {&a} , {&b} , {valid} and {&c} .', ['&a' => 'bar', '&b' => 'bar', 'valid' => 'bar', '&c' => 'bar']);
 }


### PR DESCRIPTION
https://phpstan.org/error-identifiers

> Error identifiers are used to identify and categorize all errors reported by PHPStan. In PHPStan 1.11 and later identifiers can be used to ignore a specific kind of error:

```
// @phpstan-ignore argument.type
$this->foo->doSomethingWithString(1);
```

----

This PR changes is also tried to provide better documentation.