### PR TITLE
Support `treatPhpDocTypesAsCertain`, `reporMaybes` as possible

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -16,6 +16,7 @@
     "PHPStan\\Type\\ArrayType",
     "PHPStan\\Type\\Constant\\ConstantStringType",
     "PHPStan\\Type\\ObjectType",
-    "PHPStan\\Type\\Type"
+    "PHPStan\\Type\\Type",
+    "PHPStan\\Type\\ErrorType"
   ]
 }

--- a/rules.neon
+++ b/rules.neon
@@ -16,14 +16,17 @@ rules:
 
 services:
 	-
-		class: Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
+		class: Sfp\PHPStan\Psr\Log\Rules\ContextKeyRule
 		arguments:
-			reportContextExceptionLogLevel: %sfpPsrLog.reportContextExceptionLogLevel%
+		    treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
+		    contextKeyOriginalPattern: %sfpPsrLog.contextKeyOriginalPattern%
 		tags:
 			- phpstan.rules.rule
 	-
-		class: Sfp\PHPStan\Psr\Log\Rules\ContextKeyRule
+		class: Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
 		arguments:
-			contextKeyOriginalPattern: %sfpPsrLog.contextKeyOriginalPattern%
+		    treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
+		    reportContextExceptionLogLevel: %sfpPsrLog.reportContextExceptionLogLevel%
 		tags:
 			- phpstan.rules.rule
+

--- a/rules.neon
+++ b/rules.neon
@@ -26,6 +26,7 @@ services:
 		class: Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
 		arguments:
 		    treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
+		    reportMaybes: %reportMaybes%
 		    reportContextExceptionLogLevel: %sfpPsrLog.reportContextExceptionLogLevel%
 		tags:
 			- phpstan.rules.rule

--- a/src/Rules/ContextKeyRule.php
+++ b/src/Rules/ContextKeyRule.php
@@ -29,11 +29,17 @@ final class ContextKeyRule implements Rule
 
     private const ERROR_NOT_MATCH_ORIGINAL_PATTERN = 'Parameter $context of logger method Psr\Log\LoggerInterface::%s(), key should be match %s.';
 
+    /** @var bool */
+    private $treatPhpDocTypesAsCertain;
+
     /** @var string|null */
     private $contextKeyOriginalPattern;
 
-    public function __construct(?string $contextKeyOriginalPattern = null)
-    {
+    public function __construct(
+        bool $treatPhpDocTypesAsCertain,
+        ?string $contextKeyOriginalPattern = null
+    ) {
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
         $this->contextKeyOriginalPattern = $contextKeyOriginalPattern;
     }
 
@@ -85,7 +91,11 @@ final class ContextKeyRule implements Rule
             return [];
         }
 
-        $arrayType = $scope->getType($context->value);
+        if ($this->treatPhpDocTypesAsCertain) {
+            $arrayType = $scope->getType($context->value);
+        } else {
+            $arrayType = $scope->getNativeType($context->value);
+        }
 
         if ($arrayType->isIterableAtLeastOnce()->no()) {
             // @codeCoverageIgnoreStart

--- a/test/Rules/ContextKeyRuleTest.php
+++ b/test/Rules/ContextKeyRuleTest.php
@@ -29,6 +29,7 @@ final class ContextKeyRuleTest extends RuleTestCase
 
     /**
      * @dataProvider provideNonEmptyStringKeyPattern
+     * @phpstan-param list<array{0:string, 1:int}> $expectedErrors
      */
     public function testAlwaysShouldBeCheckedNonEmptyString(bool $treatPhpDocTypesAsCertain, array $expectedErrors): void
     {
@@ -37,6 +38,9 @@ final class ContextKeyRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/contextKey_nonEmptyString.php'], $expectedErrors);
     }
 
+    /**
+     * @phpstan-return list<array{treatPhpDocTypesAsCertain: bool, list<array{0:string, 1:int}>}>
+     */
     public static function provideNonEmptyStringKeyPattern(): array
     {
         $expectedErrors = [

--- a/test/Rules/ContextRequireExceptionKeyRuleTest.php
+++ b/test/Rules/ContextRequireExceptionKeyRuleTest.php
@@ -8,22 +8,34 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule;
 
+use function count;
+
 /**
  * @extends RuleTestCase<ContextRequireExceptionKeyRule>
  * @covers \Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
  */
 final class ContextRequireExceptionKeyRuleTest extends RuleTestCase
 {
+    /** @var bool */
+    private $treatPhpDocTypesAsCertain = false;
+
+    /** @var bool */
+    private $reportMaybes = false;
+
     /** @phpstan-var 'debug'|'info' */
     private $reportContextExceptionLogLevel = 'debug';
 
     protected function getRule(): Rule
     {
-        return new ContextRequireExceptionKeyRule($this->reportContextExceptionLogLevel);
+        return new ContextRequireExceptionKeyRule(
+            $this->treatPhpDocTypesAsCertain,
+            $this->reportMaybes,
+            $this->reportContextExceptionLogLevel
+        );
     }
 
     /** @test */
-    public function shouldNotBeReportsIfLogLevelIsUnder(): void
+    public function shouldNotBeReportedIfLogLevelIsNotReached(): void
     {
         $this->reportContextExceptionLogLevel = 'info';
 
@@ -36,10 +48,40 @@ final class ContextRequireExceptionKeyRuleTest extends RuleTestCase
     }
 
     /**
+     * @testWith [ false, false, 0, [] ]
+     *           [ false, true, 0, [] ]
+     *           [ true, false, 1, [27] ]
+     *           [ true, true,  2, [24, 27] ]
+     */
+    public function testParameterSettings(
+        bool $treatPhpDocTypesAsCertain,
+        bool $reportMaybes,
+        int $expectedErrorCount,
+        array $expectedErrorLines
+    ): void {
+        $this->treatPhpDocTypesAsCertain      = $treatPhpDocTypesAsCertain;
+        $this->reportMaybes                   = $reportMaybes;
+        $this->reportContextExceptionLogLevel = 'debug';
+
+        $errors = $this->gatherAnalyserErrors([__DIR__ . '/data/ContextRequireExceptionKeyRule/parameters.php']);
+
+        $this->assertSame($expectedErrorCount, count($errors));
+
+        $errorLines = [];
+        foreach ($errors as $error) {
+            $errorLines[] = $error->getLine();
+        }
+
+        $this->assertSame($expectedErrorLines, $errorLines);
+    }
+
+    /**
      * @test
      */
     public function testProcessNode(): void
     {
+        $this->treatPhpDocTypesAsCertain      = true;
+        $this->reportMaybes                   = false;
         $this->reportContextExceptionLogLevel = 'debug';
         $this->analyse([__DIR__ . '/data/contextRequireExceptionKey.php'], [
             [

--- a/test/Rules/ContextRequireExceptionKeyRuleTest.php
+++ b/test/Rules/ContextRequireExceptionKeyRuleTest.php
@@ -48,8 +48,8 @@ final class ContextRequireExceptionKeyRuleTest extends RuleTestCase
     /**
      * @testWith [ false, false, 0, [] ]
      *           [ false, true, 0, [] ]
-     *           [ true, false, 1, [27] ]
-     *           [ true, true,  2, [24, 27] ]
+     *           [ true, false, 1, [26] ]
+     *           [ true, true,  2, [23, 26] ]
      * @phpstan-param list<int> $expectedErrorLines
      */
     public function testParameterSettings(

--- a/test/Rules/ContextRequireExceptionKeyRuleTest.php
+++ b/test/Rules/ContextRequireExceptionKeyRuleTest.php
@@ -86,19 +86,23 @@ final class ContextRequireExceptionKeyRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/contextRequireExceptionKey.php'], [
             [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::notice() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                24,
+                22,
             ],
             [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::notice() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                25,
+                23,
             ],
             [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                28,
+                26,
             ],
             [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::log() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                29,
+                27,
+            ],
+            [
+                'Parameter $context of logger method Psr\Log\LoggerInterface::notice() requires \'exception\' key. Current scope has Throwable variable - $exception',
+                31,
             ],
             [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::notice() requires \'exception\' key. Current scope has Throwable variable - $exception',
@@ -110,11 +114,7 @@ final class ContextRequireExceptionKeyRuleTest extends RuleTestCase
             ],
             [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::notice() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                37,
-            ],
-            [
-                'Parameter $context of logger method Psr\Log\LoggerInterface::notice() requires \'exception\' key. Current scope has Throwable variable - $exception',
-                38,
+                36,
             ],
             [
                 'Parameter $context of logger method Psr\Log\LoggerInterface::notice() requires \'exception\' key. Current scope has Throwable variable - $exception2',

--- a/test/Rules/ContextRequireExceptionKeyRuleTest.php
+++ b/test/Rules/ContextRequireExceptionKeyRuleTest.php
@@ -8,8 +8,6 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule;
 
-use function count;
-
 /**
  * @extends RuleTestCase<ContextRequireExceptionKeyRule>
  * @covers \Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
@@ -52,6 +50,7 @@ final class ContextRequireExceptionKeyRuleTest extends RuleTestCase
      *           [ false, true, 0, [] ]
      *           [ true, false, 1, [27] ]
      *           [ true, true,  2, [24, 27] ]
+     * @phpstan-param list<int> $expectedErrorLines
      */
     public function testParameterSettings(
         bool $treatPhpDocTypesAsCertain,
@@ -65,7 +64,7 @@ final class ContextRequireExceptionKeyRuleTest extends RuleTestCase
 
         $errors = $this->gatherAnalyserErrors([__DIR__ . '/data/ContextRequireExceptionKeyRule/parameters.php']);
 
-        $this->assertSame($expectedErrorCount, count($errors));
+        $this->assertCount($expectedErrorCount, $errors);
 
         $errorLines = [];
         foreach ($errors as $error) {

--- a/test/Rules/data/ContextRequireExceptionKeyRule/parameters.php
+++ b/test/Rules/data/ContextRequireExceptionKeyRule/parameters.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
  *
  * NOTES: union param would be reported level7(reportMaybes)
  * https://phpstan.org/r/8f1158f4-0cac-4ef9-9abe-29a892d502af
- *
  */
 function main(
     Psr\Log\LoggerInterface $logger,
@@ -23,7 +22,7 @@ function main(
         $logger->notice('foo', $context);
         $logger->notice('foo', $unionContext);
 
-        $logger->notice('foo', array_merge(['foo' => 1],  ['exception' => $exception] ));
-        $logger->notice('foo', array_merge(['foo' => 1],  ['exception2' => $exception] ));
+        $logger->notice('foo', array_merge(['foo' => 1], ['exception' => $exception]));
+        $logger->notice('foo', array_merge(['foo' => 1], ['exception2' => $exception]));
     }
 }

--- a/test/Rules/data/ContextRequireExceptionKeyRule/parameters.php
+++ b/test/Rules/data/ContextRequireExceptionKeyRule/parameters.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @phpstan-param array{exception: \Exception} $context
+ * @phpstan-param array{exception: \Exception}|array{exception2: \Exception} $unionContext
+ *
+ * NOTES: union param would be reported level7(reportMaybes)
+ * https://phpstan.org/r/8f1158f4-0cac-4ef9-9abe-29a892d502af
+ *
+ */
+function main(
+    Psr\Log\LoggerInterface $logger,
+    array $nonTypedArray,
+    array $context,
+    array $unionContext
+): void {
+    try {
+        throw new InvalidArgumentException();
+    } catch (InvalidArgumentException $exception) {
+        $logger->notice('foo', $nonTypedArray);
+        $logger->notice('foo', $context);
+        $logger->notice('foo', $unionContext);
+
+        $logger->notice('foo', array_merge(['foo' => 1],  ['exception' => $exception] ));
+        $logger->notice('foo', array_merge(['foo' => 1],  ['exception2' => $exception] ));
+    }
+}

--- a/test/Rules/data/contextKey_nonEmptyString.php
+++ b/test/Rules/data/contextKey_nonEmptyString.php
@@ -23,11 +23,11 @@ function main(Psr\Log\LoggerInterface $logger, array $nonTypedArray, array $cons
     $logger->info('foo', ["a"]);
     $logger->log('info', 'foo', ["a"]);
 
-    $logger->info('union', $constantContext);
-    $logger->info('union', $badKeyContext); // ng
-
     $okArray = ['ok' => __LINE__];
     $ngArray = [1 => __LINE__];
     $logger->info('ok', $okArray);
     $logger->info('ng', $ngArray); //ng
+
+    $logger->info('union', $constantContext);
+    $logger->info('union', $badKeyContext); // ng (when treatPhpDocTypesAsCertain on)
 }

--- a/test/Rules/data/contextRequireExceptionKey.php
+++ b/test/Rules/data/contextRequireExceptionKey.php
@@ -60,7 +60,7 @@ function main(
         // Todo - handle function return type
         $logger->log(determineLogLevel(), 'foo');
         $logger->critical('foo', returnMixedArray());
-        $logger->critical('foo', returnExceptionHasArray()); // returnExceptionHasArray would be ErrorType
+        $logger->critical('foo', returnExceptionHasArray()); // returnExceptionHasArray would be ErrorType, should not be reported
     } finally {
         // ok - when finally
         $logger->emergency('foo');

--- a/test/Rules/data/contextRequireExceptionKey.php
+++ b/test/Rules/data/contextRequireExceptionKey.php
@@ -6,13 +6,11 @@ use SfpTest\PHPStan\Psr\Log\Rules\OtherLoggerInterface;
 
 /**
  * @phpstan-param 'debug'|'info'|'notice' $logLevels
- * @phpstan-param 'none'|'foo' $badLogLevels
  */
 function main(
     Psr\Log\LoggerInterface $logger,
     OtherLoggerInterface $otherLogger,
-    array $logLevels,
-    array $badLogLevels
+    array $logLevels
 ): void {
     try {
         $logger->debug("foo"); // ok - this line's scope does not have Throwable
@@ -40,6 +38,8 @@ function main(
         // OK
         $logger->notice('foo', ['exception' => $exception]);
         $logger->log('notice', 'foo', ['exception' => $exception]);
+        // OK union log levels
+        $logger->log($logLevels, 'foo', ['exception' => $exception]);
         // OK - array variable passed pattern
         $context = ['foo' => 'bar', 'exception' => $exception]; // to check offset variable
         $logger->notice('foo', $context);
@@ -70,6 +70,7 @@ function main(
     $logger->critical();
     $logger->none('foo');
     $otherLogger->critical('message');
+
 }
 
 // phpcs:disable

--- a/test/Rules/data/contextRequireExceptionKey.php
+++ b/test/Rules/data/contextRequireExceptionKey.php
@@ -70,7 +70,6 @@ function main(
     $logger->critical();
     $logger->none('foo');
     $otherLogger->critical('message');
-
 }
 
 // phpcs:disable


### PR DESCRIPTION
### ContextKeyRule



eg.
```php
/**
 * @phpstan-param array{ok: string}|array{alsoOk: string, 123: string} $badKeyContext
 */
```

- With `treatPhpDocTypesAsCertain: true`
  - TBD...
- With: `treatPhpDocTypesAsCertain: `false`

### ContextRequireExceptionKeyRule