### PR TITLE
Support conditionalTags for ContextRequireExceptionKeyRule, MessageStaticStringRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ parameters:
         enableContextRequireExceptionKeyRule: false
 ```
 
-
 ### MessageStaticStringRule
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ parameters:
 <?php
 /** @var \Psr\Log\LoggerInterface $logger */
 try {
-    // 
+    //
 } catch (LogicException $exception) {
     $logger->warning("foo");
 }
@@ -166,6 +166,15 @@ Then, `debug`| `info` | `notice` LogLevel  is ignored for report.
 }
 ```
 
+* If you want to disable this rule, please add `enableContextRequireExceptionKeyRule` as false.
+
+```neon
+parameters:
+    sfpPsrLog:
+        enableContextRequireExceptionKeyRule: false
+```
+
+
 ### MessageStaticStringRule
 
 > [!IMPORTANT]
@@ -184,11 +193,12 @@ $logger->info(sprintf('Message contains %s variable', $var));
 
 #### Configuration
 
-* You should add `Sfp\PHPStan\Psr\Log\Rules\MessageStaticStringRule` into your `phpstan.neon` to enable.
+* If you want to enable this rule, please add `enableMessageStaticStringRule` as true.
 
 ```neon
-rules:
-    - Sfp\PHPStan\Psr\Log\Rules\MessageStaticStringRule
+parameters:
+    sfpPsrLog:
+        enableMessageStaticStringRule: true
 ```
 
 ## Installation

--- a/example/phpstan.neon
+++ b/example/phpstan.neon
@@ -3,6 +3,8 @@
 #
 # docker run -v $(realpath .):/github/workspace -w=/github/workspace ghcr.io/laminas/laminas-continuous-integration:1 \
 #  '{"php":"8.2","dependencies":"latest","extensions":[],"ini":["memory_limit=-1"],"command":"./vendor/bin/phpstan analyse -c ./example/phpstan.neon --no-progress --error-format=junit | xmllint --format -"}'
+# docker run -v $(realpath .):/github/workspace -w=/github/workspace ghcr.io/laminas/laminas-continuous-integration:1 \
+#  '{"php":"8.2","dependencies":"latest","extensions":[],"ini":["memory_limit=-1"],"command":"diff <(./vendor/bin/phpstan analyse -c ./example/phpstan.neon --no-progress --error-format=junit | xmllint --format -) ./test/example.output"}'
 
 parameters:
 	level: 5
@@ -11,13 +13,12 @@ parameters:
 	paths:
 		- %currentWorkingDirectory%/example/src
 	sfpPsrLog:
+		# enableContextRequireExceptionKeyRule: true
+		enableMessageStaticStringRule: true
 		reportContextExceptionLogLevel: 'notice'
 		contextKeyOriginalPattern: '#\A[A-Za-z0-9-]+\z#'
 	stubFiles:
 		- ../vendor/struggle-for-php/sfp-stubs-psr-log/stubs-for-throwable/LoggerInterface.phpstub
-
-rules:
-	- Sfp\PHPStan\Psr\Log\Rules\MessageStaticStringRule
 
 includes:
 # relative path can not work

--- a/rules.neon
+++ b/rules.neon
@@ -1,29 +1,38 @@
-parameters:
-	sfpPsrLog:
-		reportContextExceptionLogLevel: 'debug'
-		contextKeyOriginalPattern: null
-
 parametersSchema:
 	sfpPsrLog: structure([
+		enableContextRequireExceptionKeyRule: bool(),
+		enableMessageStaticStringRule: bool(),
 		reportContextExceptionLogLevel: schema(string(), nullable()),
 		contextKeyOriginalPattern: schema(string(), nullable())
 	])
 
+parameters:
+	sfpPsrLog:
+		enableContextRequireExceptionKeyRule: true
+		enableMessageStaticStringRule: false
+		reportContextExceptionLogLevel: 'debug'
+		contextKeyOriginalPattern: null
+
+conditionalTags:
+	Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule:
+		phpstan.rules.rule: %sfpPsrLog.enableContextRequireExceptionKeyRule%
+	Sfp\PHPStan\Psr\Log\Rules\MessageStaticStringRule:
+		phpstan.rules.rule: %sfpPsrLog.enableMessageStaticStringRule%
+
 rules:
-#	- Sfp\PHPStan\Psr\Log\Rules\MessageStaticStringRule
 	- Sfp\PHPStan\Psr\Log\Rules\PlaceholderCorrespondToKeysRule
 	- Sfp\PHPStan\Psr\Log\Rules\PlaceholderCharactersRule
 
 services:
-	-
-		class: Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
-		arguments:
-			reportContextExceptionLogLevel: %sfpPsrLog.reportContextExceptionLogLevel%
-		tags:
-			- phpstan.rules.rule
 	-
 		class: Sfp\PHPStan\Psr\Log\Rules\ContextKeyRule
 		arguments:
 			contextKeyOriginalPattern: %sfpPsrLog.contextKeyOriginalPattern%
 		tags:
 			- phpstan.rules.rule
+	-
+		class: Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule
+		arguments:
+			reportContextExceptionLogLevel: %sfpPsrLog.reportContextExceptionLogLevel%
+	-
+		class: Sfp\PHPStan\Psr\Log\Rules\MessageStaticStringRule


### PR DESCRIPTION
This feature supports enable/disable rules

```neon
parameters:
	sfpPsrLog:
		enableContextRequireExceptionKeyRule: true
		enableMessageStaticStringRule: false
```