### PR TITLE
Changed default as true - `enableLogMethodLevelRule`, `enableContextTypeRule`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 [![License](https://poser.pugx.org/struggle-for-php/sfp-phpstan-psr-log/license)](https://packagist.org/packages/struggle-for-php/sfp-phpstan-psr-log)
 [![Psalm coverage](https://shepherd.dev/github/struggle-for-php/sfp-phpstan-psr-log/coverage.svg)](https://shepherd.dev/github/struggle-for-php/sfp-phpstan-psr-log)
 
-> [!IMPORTANT]
-> The future version `0.25.0` or later will have a BC break. Please refer `Stubs` section.
-
 `struggle-for-php/sfp-phpstan-psr-log` is extra strict and opinionated psr/log (psr-3) rules for PHPStan.
 
 * [PHPStan](https://phpstan.org/)
@@ -25,39 +22,6 @@ parameters:
         reportContextExceptionLogLevel: 'info'
         contextKeyOriginalPattern: '#\A[A-Za-z0-9-_]+\z#'
 ```
-
-## Stubs
-
-> [!IMPORTANT]
-> include psr/log stub be planned to dropped in comming release.
-
-To try out the changes in the comming version,
-
-DELETE `vendor/struggle-for-php/sfp-phpstan-psr-log/extension.neon` line from your `phpstan.neon`
-
-```neon
-includes:
-    - vendor/struggle-for-php/sfp-phpstan-psr-log/extension.neon
-```
-
-and, set parameters `enableLogMethodLevelRule` and `enableContextTypeRule`
-
-```neon
-parameters:
-    sfpPsrLog:
-        enableLogMethodLevelRule: true # default:false
-        enableContextTypeRule: true # default:false
-```
-
-### About stub
-
-Currently, this extension depends on our psr/log stub to serve strictness.
-
-* eg.
-    * `@param LogLevel::*  $level` at `log()` method
-    * `@param array{exception?: \Throwable} $context`
-
-See [psr/log stub](https://github.com/struggle-for-php/sfp-stubs-psr-log) repository page to get more detail.
 
 ## Rules
 
@@ -250,6 +214,5 @@ include extension.neon & rules.neon in your project's PHPStan config:
 
 ```neon
 includes:
-    - vendor/struggle-for-php/sfp-phpstan-psr-log/extension.neon
     - vendor/struggle-for-php/sfp-phpstan-psr-log/rules.neon
 ```

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
     "extra": {
         "phpstan": {
             "includes": [
-                "extension.neon",
                 "rules.neon"
             ]
         }

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
     "require": {
         "php": "^7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-json": "*",
-        "phpstan/phpstan": "^2.1.23",
-        "struggle-for-php/sfp-stubs-psr-log": "^1.0.1 || ^2 || ^3.0.1"
+        "phpstan/phpstan": "^2.1.23"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^3",

--- a/example/phpstan.default.neon
+++ b/example/phpstan.default.neon
@@ -13,11 +13,6 @@ parameters:
 		- %currentWorkingDirectory%/vendor/autoload.php
 	paths:
 		- %currentWorkingDirectory%/example/src
-	stubFiles:
-		# relative path can not work
-		- ../vendor/struggle-for-php/sfp-stubs-psr-log/stubs-for-throwable/LoggerInterface.phpstub
 
 includes:
-# relative path can not work
-	# - %currentWorkingDirectory%/extension.neon
 	- %currentWorkingDirectory%/rules.neon

--- a/example/phpstan.recommend.neon
+++ b/example/phpstan.recommend.neon
@@ -18,11 +18,6 @@ parameters:
 		enableMessageStaticStringRule: true
 		reportContextExceptionLogLevel: 'notice'
 		contextKeyOriginalPattern: '#\A[A-Za-z0-9-]+\z#'
-		enableContextTypeRule: false
-	stubFiles:
-		- ../vendor/struggle-for-php/sfp-stubs-psr-log/stubs-for-throwable/LoggerInterface.phpstub
 
 includes:
-# relative path can not work
-	# - %currentWorkingDirectory%/extension.neon
 	- %currentWorkingDirectory%/rules.neon

--- a/rules.neon
+++ b/rules.neon
@@ -14,8 +14,8 @@ parameters:
 		enableMessageStaticStringRule: true
 		reportContextExceptionLogLevel: 'debug'
 		contextKeyOriginalPattern: null
-		enableLogMethodLevelRule: false
-		enableContextTypeRule: false
+		enableLogMethodLevelRule: true
+		enableContextTypeRule: true
 
 conditionalTags:
 	Sfp\PHPStan\Psr\Log\Rules\ContextRequireExceptionKeyRule:

--- a/src/Rules/ContextTypeRule.php
+++ b/src/Rules/ContextTypeRule.php
@@ -17,6 +17,7 @@ use Sfp\PHPStan\Psr\Log\TypeProviderResolver\AnyScopeContextTypeProviderResolver
 use Sfp\PHPStan\Psr\Log\TypeProviderResolver\ContextTypeProviderResolverInterface;
 
 use function count;
+use function implode;
 use function in_array;
 use function sprintf;
 
@@ -89,16 +90,23 @@ final class ContextTypeRule implements Rule
             return [];
         }
 
+        $ruleErrorBuilder = RuleErrorBuilder::message(
+            sprintf(
+                'Parameter #%d $context of method Psr\Log\LoggerInterface::%s() expects %s, %s given.',
+                $contextArgumentNo + 1,
+                $methodName,
+                (string) $acceptingContextType->toPhpDocNode(),
+                (string) $argContextType->toPhpDocNode()
+            )
+        )
+            ->identifier('sfpPsrLog.contextType');
+
+        if (count($acceptsResult->reasons) > 0) {
+            $ruleErrorBuilder->tip(implode(',', $acceptsResult->reasons));
+        }
+
         return [
-            RuleErrorBuilder::message(
-                sprintf(
-                    'Parameter #%d $context of method Psr\Log\LoggerInterface::%s() expects %s, %s given.',
-                    $contextArgumentNo + 1,
-                    $methodName,
-                    (string) $acceptingContextType->toPhpDocNode(),
-                    (string) $argContextType->toPhpDocNode()
-                )
-            )->identifier('sfpPsrLog.contextType')->build(),
+            $ruleErrorBuilder->build(),
         ];
     }
 }

--- a/test/Rules/ContextTypeRuleTest.php
+++ b/test/Rules/ContextTypeRuleTest.php
@@ -63,7 +63,10 @@ final class ContextTypeRuleTest extends RuleTestCase
     public static function provideContextTypePattern(): array
     {
         $expectedError = [
-            'Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects array{exception?: Throwable}, array{exception: string} given.',
+            <<<'EOF'
+Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects array{exception?: Throwable}, array{exception: string} given.
+    💡 Offset 'exception' (Throwable) does not accept type string.
+EOF,
             19,
         ];
 
@@ -79,7 +82,10 @@ final class ContextTypeRuleTest extends RuleTestCase
                 'expectedErrors'  => [
                     $expectedError,
                     [
-                        'Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects array{exception?: Throwable}, (array{exception: string} | array{exception: Throwable}) given.',
+                        <<<'EOF'
+Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects array{exception?: Throwable}, (array{exception: string} | array{exception: Throwable}) given.
+    💡 Offset 'exception' (Throwable) does not accept type string.
+EOF,
                         20,
                     ],
                 ],
@@ -97,13 +103,24 @@ final class ContextTypeRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/contextType.php'], [
             [
                 sprintf(
-                    'Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects %s, array{exception: string} given.',
-                    'array{first_name?: string, product?: array{id?: string}, cancellation_reason?: (float | int | numeric-string), cancellation_date?: \DateTimeInterface, exception?: \Throwable}'
+                    <<<'EOF'
+Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects %s, %s given.
+    💡 Offset 'exception' (Throwable) does not accept type string.
+EOF,
+                    'array{first_name?: string, product?: array{id?: string}, cancellation_reason?: (float | int | numeric-string), cancellation_date?: \DateTimeInterface, exception?: \Throwable}',
+                    'array{exception: string}'
                 ),
                 19,
             ],
             [
-                'Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects array{first_name?: string, product?: array{id?: string}, cancellation_reason?: (float | int | numeric-string), cancellation_date?: \DateTimeInterface, exception?: \Throwable}, (array{exception: string} | array{exception: Throwable}) given.',
+                sprintf(
+                    <<<'EOF'
+Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects %s, %s given.
+    💡 Offset 'exception' (Throwable) does not accept type string.
+EOF,
+                    'array{first_name?: string, product?: array{id?: string}, cancellation_reason?: (float | int | numeric-string), cancellation_date?: \DateTimeInterface, exception?: \Throwable}',
+                    '(array{exception: string} | array{exception: Throwable})'
+                ),
                 20,
             ],
         ]);

--- a/test/example.default.output
+++ b/test/example.default.output
@@ -4,7 +4,7 @@
     <failure type="ERROR" message="Parameter #2 $context of method Psr\Log\LoggerInterface::notice() expects array{exception?: Throwable}, array{exception: string} given."/>
   </testcase>
   <testcase name="example/src/Example.php:27">
-    <failure type="ERROR" message="Parameter #1 $level of method Psr\Log\LoggerInterface::log() expects 'alert'|'critical'|'debug'|'emergency'|'error'|'info'|'notice'|'warning', 'panic' given."/>
+    <failure type="ERROR" message="Parameter #1 $level of method Psr\Log\LoggerInterface::log() expects ('alert' | 'critical' | 'debug' | 'emergency' | 'error' | 'info' | 'notice' | 'warning'), 'panic' given."/>
   </testcase>
   <testcase name="example/src/Example.php:52">
     <failure type="ERROR" message="Parameter $context of logger method Psr\Log\LoggerInterface::debug(), key should be non empty string."/>

--- a/test/example.recommend.output
+++ b/test/example.recommend.output
@@ -4,7 +4,7 @@
     <failure type="ERROR" message="Parameter #2 $context of method Psr\Log\LoggerInterface::notice() expects array{exception?: Throwable}, array{exception: string} given."/>
   </testcase>
   <testcase name="example/src/Example.php:27">
-    <failure type="ERROR" message="Parameter #1 $level of method Psr\Log\LoggerInterface::log() expects 'alert'|'critical'|'debug'|'emergency'|'error'|'info'|'notice'|'warning', 'panic' given."/>
+    <failure type="ERROR" message="Parameter #1 $level of method Psr\Log\LoggerInterface::log() expects ('alert' | 'critical' | 'debug' | 'emergency' | 'error' | 'info' | 'notice' | 'warning'), 'panic' given."/>
   </testcase>
   <testcase name="example/src/Example.php:37">
     <failure type="ERROR" message="Parameter $context of logger method Psr\Log\LoggerInterface::notice() requires 'exception' key. Current scope has Throwable variable - $throwable"/>


### PR DESCRIPTION
- fix #82

----

- Removed stub dependency - Removed `struggle-for-php/sfp-stubs-psr-log` from composer.json and all references to extension.neon
- Changed default configuration - In rules.neon
    - enableLogMethodLevelRule: false → true
    - enableContextTypeRule: false → true
- Improved error messages - In ContextTypeRule.php:93-106, added tips (reasons) to type error messages
- Cleaned up README - Removed 37-line stub-related documentation section for simpler documentation

### Before

```
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Example.php
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  26     Parameter #2 $context of method Psr\Log\LoggerInterface::notice() expects array{exception?: Throwable}, array{exception: string} given.
         🪪  argument.type
         💡  Offset 'exception' (Throwable) does not accept type string.
  27     Parameter #1 $level of method Psr\Log\LoggerInterface::log() expects 'alert'|'critical'|'debug'|'emergency'|'error'|'info'|'notice'|'warning', 'panic' given.
         🪪  argument.type
```

### After


```
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Example.php
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  26     Parameter #2 $context of method Psr\Log\LoggerInterface::notice() expects array{exception?: Throwable}, array{exception: string} given.
         🪪  sfpPsrLog.contextType
         💡  Offset 'exception' (Throwable) does not accept type string.
  27     Parameter #1 $level of method Psr\Log\LoggerInterface::log() expects ('alert' | 'critical' | 'debug' | 'emergency' | 'error' | 'info' | 'notice' | 'warning'), 'panic' given.
         🪪  sfpPsrLog.logMethodLevel
```