### PR TITLE
MessageStaticStringRule should allow `literal-string` as static message

### DIFF
--- a/src/Rules/MessageStaticStringRule.php
+++ b/src/Rules/MessageStaticStringRule.php
@@ -71,10 +71,9 @@ final class MessageStaticStringRule implements Rule
         }
 
         $message = $args[$messageArgumentNo];
-        $value   = $scope->getType($message->value);
-        $strings = $value->getConstantStrings();
+        $type    = $scope->getType($message->value);
 
-        if (count($strings) === 0) {
+        if ($type->isLiteralString()->maybe()) {
             return [
                 RuleErrorBuilder::message(
                     sprintf(self::ERROR_MESSAGE_NOT_STATIC, $methodName)

--- a/test/Rules/data/messageMustBeStatic.php
+++ b/test/Rules/data/messageMustBeStatic.php
@@ -34,3 +34,11 @@ function main(Psr\Log\LoggerInterface $logger, string $m, string $literals, stri
     // Allow literal-string intersection
     $logger->info($literals);
 }
+
+/**
+ * @param literal-string $literal
+ */
+function logging(Psr\Log\LoggerInterface $logger, string $literal): void
+{
+	$logger->info($literal);
+}


### PR DESCRIPTION
Allow below case

```php
/**
 * @param literal-string $literal
 */
function logging(Psr\Log\LoggerInterface $logger, string $literal): void
{
	$logger->info($literal);
}
```