### PR TITLE
Return unsealed context shapes for PHPStan 2.2 compatibility

### DIFF
--- a/src/Internal/UnsealedConstantArrayShape.php
+++ b/src/Internal/UnsealedConstantArrayShape.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sfp\PHPStan\Psr\Log\Internal;
+
+use PHPStan\Type\BenevolentUnionType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+
+use function method_exists;
+
+/**
+ * Marks a {@see ConstantArrayType} produced via the PHPStan API as unsealed
+ * (the {@code array{foo?: Bar, ...}} form).
+ *
+ * PHPStan 2.2 distinguishes sealed and unsealed array shapes; user-provided
+ * log contexts almost always carry extra keys, so the expected context type
+ * must permit them. On older PHPStan releases that do not expose the unsealed
+ * API, the original type is returned unchanged — preserving prior behaviour.
+ *
+ * @internal
+ */
+final class UnsealedConstantArrayShape
+{
+    public static function apply(ConstantArrayType $type): ConstantArrayType
+    {
+        /** @phpstan-ignore function.alreadyNarrowedType, function.impossibleType */
+        if (! method_exists(ConstantArrayTypeBuilder::class, 'makeUnsealed')) {
+            return $type;
+        }
+
+        $builder = ConstantArrayTypeBuilder::createFromConstantArray($type);
+        /** @phpstan-ignore method.notFound */
+        $builder->makeUnsealed(
+            (new BenevolentUnionType([new IntegerType(), new StringType()]))->toArrayKey(),
+            new MixedType()
+        );
+
+        $constantArrays = $builder->getArray()->getConstantArrays();
+
+        return $constantArrays === [] ? $type : $constantArrays[0];
+    }
+}

--- a/src/TypeMapping/BigQuery/GenericTableFieldSchemaJsonPayloadTypeMapper.php
+++ b/src/TypeMapping/BigQuery/GenericTableFieldSchemaJsonPayloadTypeMapper.php
@@ -15,6 +15,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use Sfp\PHPStan\Psr\Log\Internal\UnsealedConstantArrayShape;
 use Sfp\PHPStan\Psr\Log\TypeMapping\BigQuery\Exception\UnsupportedTypeException;
 use UnexpectedValueException;
 
@@ -65,7 +66,9 @@ final class GenericTableFieldSchemaJsonPayloadTypeMapper implements TableFieldSc
                     // if ($nestedLevel > 2) {
                     //    continue;
                     // }
-                    $valueTypes[] = self::convertFieldsToTypes($item['fields'], ++$nestedLevel);
+                    $valueTypes[] = UnsealedConstantArrayShape::apply(
+                        self::convertFieldsToTypes($item['fields'], ++$nestedLevel)
+                    );
                 } else {
                     $valueTypes[] = $objectType;
                 }

--- a/src/TypeProvider/BigQueryContextTypeProvider.php
+++ b/src/TypeProvider/BigQueryContextTypeProvider.php
@@ -11,6 +11,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use RuntimeException;
+use Sfp\PHPStan\Psr\Log\Internal\UnsealedConstantArrayShape;
 use Sfp\PHPStan\Psr\Log\TypeMapping\BigQuery\TableFieldSchemaJsonPayloadTypeMapperInterface;
 use UnexpectedValueException;
 
@@ -53,7 +54,10 @@ final class BigQueryContextTypeProvider implements ContextTypeProviderInterface
             true
         );
 
-        return $builder->getArray();
+        $array          = $builder->getArray();
+        $constantArrays = $array->getConstantArrays();
+
+        return $constantArrays === [] ? $array : UnsealedConstantArrayShape::apply($constantArrays[0]);
     }
 
     /**

--- a/src/TypeProvider/Psr3ContextTypeProvider.php
+++ b/src/TypeProvider/Psr3ContextTypeProvider.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use Sfp\PHPStan\Psr\Log\Internal\UnsealedConstantArrayShape;
 use Throwable;
 
 final class Psr3ContextTypeProvider implements ContextTypeProviderInterface
@@ -25,11 +26,11 @@ final class Psr3ContextTypeProvider implements ContextTypeProviderInterface
     #[Override]
     public function getType(): Type
     {
-        return new ConstantArrayType(
+        return UnsealedConstantArrayShape::apply(new ConstantArrayType(
             [new ConstantStringType('exception')],
             [new ObjectType($this->exceptionClass)],
             [0],
             [0]
-        );
+        ));
     }
 }

--- a/test/Rules/ContextTypeRuleTest.php
+++ b/test/Rules/ContextTypeRuleTest.php
@@ -7,12 +7,14 @@ namespace SfpTest\PHPStan\Psr\Log\Rules;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use Sfp\PHPStan\Psr\Log\Rules\ContextTypeRule;
 use Sfp\PHPStan\Psr\Log\TypeMapping\BigQuery\GenericTableFieldSchemaJsonPayloadTypeMapper;
 use Sfp\PHPStan\Psr\Log\TypeProvider\BigQueryContextTypeProvider;
 use Sfp\PHPStan\Psr\Log\TypeProviderResolver\AnyScopeContextTypeProviderResolver;
 use Sfp\PHPStan\Psr\Log\TypeProviderResolver\ContextTypeProviderResolverInterface;
 
+use function method_exists;
 use function sprintf;
 
 /**
@@ -62,9 +64,11 @@ final class ContextTypeRuleTest extends RuleTestCase
      */
     public static function provideContextTypePattern(): array
     {
+        $expected = self::expectedContextShape();
+
         $expectedError = [
-            <<<'EOF'
-Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects array{exception?: Throwable}, array{exception: string} given.
+            <<<EOF
+Parameter #2 \$context of method Psr\Log\LoggerInterface::info() expects $expected, array{exception: string} given.
     💡 Offset 'exception' (Throwable) does not accept type string.
 EOF,
             19,
@@ -82,8 +86,8 @@ EOF,
                 'expectedErrors'  => [
                     $expectedError,
                     [
-                        <<<'EOF'
-Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects array{exception?: Throwable}, (array{exception: string} | array{exception: Throwable}) given.
+                        <<<EOF
+Parameter #2 \$context of method Psr\Log\LoggerInterface::info() expects $expected, (array{exception: string} | array{exception: Throwable}) given.
     💡 Offset 'exception' (Throwable) does not accept type string.
 EOF,
                         20,
@@ -100,6 +104,7 @@ EOF,
     {
         $contextTypeProvider               = new BigQueryContextTypeProvider(__DIR__ . '/../TypeProvider/data/bigQuerySchema.json', new GenericTableFieldSchemaJsonPayloadTypeMapper());
         $this->contextTypeProviderResolver = new AnyScopeContextTypeProviderResolver($contextTypeProvider);
+        $expected                          = self::expectedBigQueryShape();
         $this->analyse([__DIR__ . '/data/contextType.php'], [
             [
                 sprintf(
@@ -107,7 +112,7 @@ EOF,
 Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects %s, %s given.
     💡 Offset 'exception' (Throwable) does not accept type string.
 EOF,
-                    'array{first_name?: string, product?: array{id?: string}, cancellation_reason?: (float | int | numeric-string), cancellation_date?: \DateTimeInterface, exception?: \Throwable}',
+                    $expected,
                     'array{exception: string}'
                 ),
                 19,
@@ -118,11 +123,31 @@ EOF,
 Parameter #2 $context of method Psr\Log\LoggerInterface::info() expects %s, %s given.
     💡 Offset 'exception' (Throwable) does not accept type string.
 EOF,
-                    'array{first_name?: string, product?: array{id?: string}, cancellation_reason?: (float | int | numeric-string), cancellation_date?: \DateTimeInterface, exception?: \Throwable}',
+                    $expected,
                     '(array{exception: string} | array{exception: Throwable})'
                 ),
                 20,
             ],
         ]);
+    }
+
+    private static function expectedContextShape(): string
+    {
+        return self::unsealedShapesSupported()
+            ? 'array{exception?: Throwable, ...}'
+            : 'array{exception?: Throwable}';
+    }
+
+    private static function expectedBigQueryShape(): string
+    {
+        return self::unsealedShapesSupported()
+            ? 'array{first_name?: string, product?: array{id?: string, ...}, cancellation_reason?: (float | int | numeric-string), cancellation_date?: \DateTimeInterface, exception?: \Throwable, ...}'
+            : 'array{first_name?: string, product?: array{id?: string}, cancellation_reason?: (float | int | numeric-string), cancellation_date?: \DateTimeInterface, exception?: \Throwable}';
+    }
+
+    private static function unsealedShapesSupported(): bool
+    {
+        /** @phpstan-ignore function.alreadyNarrowedType, function.impossibleType */
+        return method_exists(ConstantArrayTypeBuilder::class, 'makeUnsealed');
     }
 }


### PR DESCRIPTION
Closes: #100

PHPStan 2.2 introduces sealed array shapes under bleedingEdge, so the sealed `array{exception?: Throwable}` returned by the Psr3 and BigQuery context type providers rejected real user contexts carrying extra keys. Route every provider result through a new `UnsealedConstantArrayShape` helper so the expected shape becomes `array{exception?: Throwable, ...}`. A `method_exists` guard keeps behaviour unchanged on PHPStan 2.1.x.